### PR TITLE
#4 chore: add travisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: node_js
+node_js:
+  - "8"
+cache: yarn
+script:
+  - echo 'Build starts'
+  - echo 'Installing Dependencies'
+  - yarn
+  - echo 'Linting'
+  - yarn lint
+  - echo 'Building project'
+  - yarn build


### PR DESCRIPTION
This PR adds TravisCI to our project. 

Blocked by #27 because Travis runs `yarn lint`.