### PR TITLE
Fix/video overlay fixes

### DIFF
--- a/src/Video.js
+++ b/src/Video.js
@@ -16,7 +16,7 @@ class VideoApp extends React.Component {
       <div className="VideoApp">
         <CanvasBias u={0.7} v={0.5} w={0.3} />
         <CanvasHeading heading={72.57387} />
-        <CanvasDepth depth={1.25479} />
+        <CanvasDepth depth={8.3726} />
         <VideoFeed />
       </div>
     );

--- a/src/Video.js
+++ b/src/Video.js
@@ -14,9 +14,9 @@ class VideoApp extends React.Component {
   render() {
     return (
       <div className="VideoApp">
-        <CanvasBias u={0.4} v={0.5} w={0.3} />
-        <CanvasHeading heading={60} />
-        <CanvasDepth depth={5} />
+        <CanvasBias u={0.7} v={0.5} w={0.3} />
+        <CanvasHeading heading={72.57387} />
+        <CanvasDepth depth={1.25479} />
         <VideoFeed />
       </div>
     );

--- a/src/Video.js
+++ b/src/Video.js
@@ -16,7 +16,7 @@ class VideoApp extends React.Component {
       <div className="VideoApp">
         <CanvasBias u={0.4} v={0.5} w={0.3} />
         <CanvasHeading heading={60} />
-        <CanvasDepth depth={1.5} />
+        <CanvasDepth depth={5} />
         <VideoFeed />
       </div>
     );

--- a/src/VideoComponents/canvasComponents/component_bias.js
+++ b/src/VideoComponents/canvasComponents/component_bias.js
@@ -15,7 +15,7 @@ class CanvasBias extends Canvas {
 
 class PureCanvasBias extends PureCanvas {
   constructor(props) {
-    super(props, 'canvasBias', 500, 500);
+    super(props, 'canvasBias', 360, 360);
   }
 }
 

--- a/src/VideoComponents/canvasComponents/component_depth.js
+++ b/src/VideoComponents/canvasComponents/component_depth.js
@@ -16,7 +16,7 @@ class CanvasDepth extends Canvas {
 
 class PureCanvasDepth extends PureCanvas {
   constructor(props) {
-    super(props, 'canvasDepth', 75, 500);
+    super(props, 'canvasDepth', 75, 800);
   }
 }
 

--- a/src/VideoComponents/canvasComponents/component_depth.js
+++ b/src/VideoComponents/canvasComponents/component_depth.js
@@ -16,7 +16,7 @@ class CanvasDepth extends Canvas {
 
 class PureCanvasDepth extends PureCanvas {
   constructor(props) {
-    super(props, 'canvasDepth', 75, 800);
+    super(props, 'canvasDepth', 120, 800);
   }
 }
 

--- a/src/VideoComponents/canvasComponents/component_heading.js
+++ b/src/VideoComponents/canvasComponents/component_heading.js
@@ -16,7 +16,7 @@ class CanvasHeading extends Canvas {
 
 class PureCanvasHeading extends PureCanvas {
   constructor(props) {
-    super(props, 'canvasHeading', 800, 75);
+    super(props, 'canvasHeading', 800, 100);
   }
 }
 

--- a/src/VideoComponents/css/overlay.css
+++ b/src/VideoComponents/css/overlay.css
@@ -13,8 +13,8 @@ img {
 }
 
 #canvasHeading {
-  left: 0;
-  right: 0;
+  left: -9999px;
+  right: -9999px;
   margin: auto;
 }
 

--- a/src/VideoComponents/css/overlay.css
+++ b/src/VideoComponents/css/overlay.css
@@ -8,8 +8,6 @@ img {
 }
 
 #canvasBias {
-  /*height: 300px;
-  width: 300px;*/
   right: 50px;
   bottom: 50px;
 }
@@ -18,12 +16,9 @@ img {
   left: 0;
   right: 0;
   margin: auto;
-  /*width: 100%;
-  height: auto;*/
 }
 
 #canvasDepth {
   top: 75px;
-  /*height: 90%;
-  width: auto;*/
+  left: 10px;
 }

--- a/src/VideoComponents/css/overlay.css
+++ b/src/VideoComponents/css/overlay.css
@@ -13,6 +13,7 @@ img {
 }
 
 #canvasHeading {
+  /* This centers the widget, even in the case where the windows becomes too small when resizing */
   left: -9999px;
   right: -9999px;
   margin: auto;

--- a/src/VideoComponents/css/overlay.css
+++ b/src/VideoComponents/css/overlay.css
@@ -8,20 +8,22 @@ img {
 }
 
 #canvasBias {
-  height: 300px;
-  width: 300px;
-  right: 0;
-  bottom: -50px;
+  /*height: 300px;
+  width: 300px;*/
+  right: 50px;
+  bottom: 50px;
 }
 
 #canvasHeading {
-  left: 75px;
-  width: 100%;
-  height: auto;
+  left: 0;
+  right: 0;
+  margin: auto;
+  /*width: 100%;
+  height: auto;*/
 }
 
 #canvasDepth {
   top: 75px;
-  height: 90%;
-  width: auto;
+  /*height: 90%;
+  width: auto;*/
 }

--- a/src/VideoComponents/js/bias.js
+++ b/src/VideoComponents/js/bias.js
@@ -26,11 +26,6 @@ const start_w_y = 30;
 const end_w_x = 180;
 const end_w_y = 330;
 
-// Variables for dummy animation
-/*var mult_u = 1;
-var mult_v = 1;
-var mult_w = 1;*/
-
 function canvas_arrow(context_bias, fromx, fromy, tox, toy, bias) {
   // Do not draw anything if there is no bias
   if (bias === 0.0) {
@@ -83,7 +78,12 @@ function map_range(old_value, old_min, old_max, new_min, new_max) {
 
 function drawBias(context_bias, u, v, w) {
   // Clear the canvas before redrawing
-  context_bias.clearRect(0, 0, 500, 500);
+  context_bias.clearRect(
+    0,
+    0,
+    context_bias.canvas.clientWidth,
+    context_bias.canvas.clientHeight,
+  );
 
   // Set the initial color and stroke thickness
   context_bias.strokeStyle = color_base_bias;
@@ -153,28 +153,6 @@ function drawBias(context_bias, u, v, w) {
   context_bias.fillText('V+', end_v_x + 8, end_v_y + 3);
   context_bias.fillText('W-', start_w_x - 8, start_w_y - 8);
   context_bias.fillText('W+', end_w_x - 8, end_w_y + 20);
-
-  // Dummy animation
-  /*u += 0.01 * mult_u;
-  if (u >= 1) {
-    mult_u = -1;
-  } else if (u <= -1) {
-    mult_u = 1;
-  }
-
-  v += 0.01 * mult_v;
-  if (v >= 1) {
-    mult_v = -1;
-  } else if (v <= -1) {
-    mult_v = 1;
-  }
-
-  w += 0.01 * mult_w;
-  if (w >= 1) {
-    mult_w = -1;
-  } else if (w <= -1) {
-    mult_w = 1;
-  }*/
 }
 
 export default drawBias;

--- a/src/VideoComponents/js/bias.js
+++ b/src/VideoComponents/js/bias.js
@@ -26,6 +26,10 @@ const start_w_y = 30;
 const end_w_x = 180;
 const end_w_y = 330;
 
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
 // Function for drawing an arrow on the canvas
 function canvas_arrow(context_bias, fromx, fromy, tox, toy, bias) {
   // Do not draw anything if there is no bias
@@ -78,6 +82,10 @@ function map_range(old_value, old_min, old_max, new_min, new_max) {
 }
 
 function drawBias(context_bias, u, v, w) {
+  u = clamp(u, -1.0, 1.0);
+  v = clamp(v, -1.0, 1.0);
+  w = clamp(w, -1.0, 1.0);
+
   // Clear the canvas before redrawing
   context_bias.clearRect(
     0,

--- a/src/VideoComponents/js/bias.js
+++ b/src/VideoComponents/js/bias.js
@@ -26,6 +26,7 @@ const start_w_y = 30;
 const end_w_x = 180;
 const end_w_y = 330;
 
+// Function for clamping a value between a minimum and maximum value
 function clamp(value, min, max) {
   return Math.min(Math.max(value, min), max);
 }
@@ -82,6 +83,7 @@ function map_range(old_value, old_min, old_max, new_min, new_max) {
 }
 
 function drawBias(context_bias, u, v, w) {
+  // Clamp the bias values between -1.0 and 1.0
   u = clamp(u, -1.0, 1.0);
   v = clamp(v, -1.0, 1.0);
   w = clamp(w, -1.0, 1.0);
@@ -150,6 +152,7 @@ function drawBias(context_bias, u, v, w) {
     w,
   );
 
+  // Set formatting for the axis labels
   context_bias.strokeStyle = color_base_bias;
   context_bias.fillStyle = color_base_bias;
   context_bias.lineWidth = 1;

--- a/src/VideoComponents/js/bias.js
+++ b/src/VideoComponents/js/bias.js
@@ -26,6 +26,7 @@ const start_w_y = 30;
 const end_w_x = 180;
 const end_w_y = 330;
 
+// Function for drawing an arrow on the canvas
 function canvas_arrow(context_bias, fromx, fromy, tox, toy, bias) {
   // Do not draw anything if there is no bias
   if (bias === 0.0) {
@@ -91,16 +92,16 @@ function drawBias(context_bias, u, v, w) {
   context_bias.lineWidth = 3;
 
   // U- to U+
-  canvas_arrow(context_bias, start_u_x, start_u_y, end_u_x, end_u_y);
-  canvas_arrow(context_bias, end_u_x, end_u_y, start_u_x, start_u_y);
+  canvas_arrow(context_bias, center_x, center_y, end_u_x, end_u_y);
+  canvas_arrow(context_bias, center_x, center_y, start_u_x, start_u_y);
 
   // V- to V+
-  canvas_arrow(context_bias, start_v_x, start_v_y, end_v_x, end_v_y);
-  canvas_arrow(context_bias, end_v_x, end_v_y, start_v_x, start_v_y);
+  canvas_arrow(context_bias, center_x, center_y, end_v_x, end_v_y);
+  canvas_arrow(context_bias, center_x, center_y, start_v_x, start_v_y);
 
   // W- to W+
-  canvas_arrow(context_bias, start_w_x, start_w_y, end_w_x, end_w_y);
-  canvas_arrow(context_bias, end_w_x, end_w_y, start_w_x, start_w_y);
+  canvas_arrow(context_bias, center_x, center_y, end_w_x, end_w_y);
+  canvas_arrow(context_bias, center_x, center_y, start_w_x, start_w_y);
 
   // U bias (red)
   reset_color(context_bias);

--- a/src/VideoComponents/js/bias.js
+++ b/src/VideoComponents/js/bias.js
@@ -1,3 +1,5 @@
+import { clamp } from './tools.js';
+
 // Color values
 const color_base_bias = '#A0A0A0';
 const color_u = '#FF0000';
@@ -25,11 +27,6 @@ const start_w_x = 180;
 const start_w_y = 30;
 const end_w_x = 180;
 const end_w_y = 330;
-
-// Function for clamping a value between a minimum and maximum value
-function clamp(value, min, max) {
-  return Math.min(Math.max(value, min), max);
-}
 
 // Function for drawing an arrow on the canvas
 function canvas_arrow(context_bias, fromx, fromy, tox, toy, bias) {

--- a/src/VideoComponents/js/depth.js
+++ b/src/VideoComponents/js/depth.js
@@ -1,3 +1,5 @@
+import { clamp } from './tools.js';
+
 function depth_init(context_depth) {
   // Basic formatting
   const color_base = '#FFFFFF';
@@ -9,6 +11,9 @@ function depth_init(context_depth) {
 const num_space = 50; // Spacing between the numerical labels
 
 function drawDepth(context_depth, depth) {
+  // Clamp the depth between 0.0 and 200.0;
+  depth = clamp(depth, 0.0, 200.0);
+
   var offset_depth = depth;
 
   // Clear the canvas every frame (except the rightmost triangle, which is static)

--- a/src/VideoComponents/js/depth.js
+++ b/src/VideoComponents/js/depth.js
@@ -9,17 +9,13 @@ function depth_init(context_depth) {
   draw_indicator_depth(context_depth);
 }
 
-// Dummy animation
-/*var offset_depth = 0;
-var offset_depth_mult = -1;*/
-
 function drawDepth(context_depth, depth) {
   const num_space = 50; // Spacing between the numerical labels
 
   var offset_depth = depth;
 
   // Clear the canvas every frame (except the rightmost triangle, which is static)
-  context_depth.clearRect(0, 0, 47, 500);
+  context_depth.clearRect(0, 0, 47, context_depth.canvas.clientHeight);
 
   // Add 200 labels (the ROV never descends more than 200 meters)
   for (var i = 0; i < 201; i++) {
@@ -41,16 +37,6 @@ function drawDepth(context_depth, depth) {
     context_depth.lineTo(47, y_position);
     context_depth.stroke();
   }
-
-  // Dummy animation
-  /*if (y_position <= 250) {
-    offset_depth_mult = 1;
-  } else if (y_position >= 201 * num_space + 250) {
-    offset_depth_mult = -1;
-  }
-
-  // Dummy animation
-  offset_depth += 5 * offset_depth_mult;*/
 }
 
 function draw_indicator_depth(context_depth) {

--- a/src/VideoComponents/js/depth.js
+++ b/src/VideoComponents/js/depth.js
@@ -3,19 +3,24 @@ function depth_init(context_depth) {
   const color_base = '#FFFFFF';
   context_depth.strokeStyle = color_base;
   context_depth.fillStyle = color_base;
-  context_depth.textAlign = 'right';
   context_depth.textBaseline = 'middle';
-
-  draw_indicator_depth(context_depth);
 }
 
-function drawDepth(context_depth, depth) {
-  const num_space = 50; // Spacing between the numerical labels
+const num_space = 50; // Spacing between the numerical labels
 
+function drawDepth(context_depth, depth) {
   var offset_depth = depth;
 
   // Clear the canvas every frame (except the rightmost triangle, which is static)
-  context_depth.clearRect(0, 0, 47, context_depth.canvas.clientHeight);
+  context_depth.clearRect(
+    0,
+    0,
+    context_depth.canvas.clientWidth,
+    context_depth.canvas.clientHeight,
+  );
+
+  // Text formatting for the depth labels
+  context_depth.textAlign = 'right';
 
   // Add 200 labels (the ROV never descends more than 200 meters)
   for (var i = 0; i < 201; i++) {
@@ -37,9 +42,13 @@ function drawDepth(context_depth, depth) {
     context_depth.lineTo(47, y_position);
     context_depth.stroke();
   }
-}
 
-function draw_indicator_depth(context_depth) {
+  // Draw number showing the numerical value of the depth
+  context_depth.textAlign = 'left';
+  context_depth.font = '18px Arial';
+
+  context_depth.fillText(depth.toFixed(2), 80, 250);
+
   // Draw the static indicator triangle
   context_depth.beginPath();
   context_depth.moveTo(50, 250);

--- a/src/VideoComponents/js/heading.js
+++ b/src/VideoComponents/js/heading.js
@@ -20,7 +20,7 @@ function drawHeading(context_heading, degrees) {
     degree_space * (120 / degree_step) - (degrees / degree_step) * degree_space;
 
   // Clear the screen (except the bottom triangle, which does not move!)
-  context_heading.clearRect(0, 0, 800, 53);
+  context_heading.clearRect(0, 0, context_heading.canvas.clientWidth, 47);
 
   // Optional separator line
   /* context_heading.beginPath();
@@ -79,9 +79,6 @@ function drawHeading(context_heading, degrees) {
     context_heading.lineTo(x_position, 53);
     context_heading.stroke();
   }
-
-  // Dummy animation
-  //offset_heading -= 3;
 }
 
 function draw_indicator_heading(context_heading) {

--- a/src/VideoComponents/js/heading.js
+++ b/src/VideoComponents/js/heading.js
@@ -4,23 +4,20 @@ function heading_init(context_heading) {
   context_heading.strokeStyle = color_base_heading;
   context_heading.fillStyle = color_base_heading;
   context_heading.textAlign = 'center';
-
-  // Draw the indicator triangle
-  draw_indicator_heading(context_heading);
 }
 
-//var offset_heading = 0; // Number holding the current offset_heading of the widget
-
 function drawHeading(context_heading, degrees) {
-  var degree_step = 15; // Number of degrees between each displayed number
-  var degree_space = 50; // Spacing between each displayed number
+  const width = context_heading.canvas.clientWidth;
+  const width_half = width / 2;
+
+  const degree_step = 15; // Number of degrees between each displayed number
+  const degree_space = 50; // Spacing between each displayed number
 
   // Convert degrees to pixel offset
-  var heading =
-    degree_space * (120 / degree_step) - (degrees / degree_step) * degree_space;
+  const heading = (degree_space * (120 - degrees)) / degree_step;
 
   // Clear the screen (except the bottom triangle, which does not move!)
-  context_heading.clearRect(0, 0, context_heading.canvas.clientWidth, 47);
+  context_heading.clearRect(0, 0, width, context_heading.canvas.clientHeight);
 
   // Optional separator line
   /* context_heading.beginPath();
@@ -79,15 +76,17 @@ function drawHeading(context_heading, degrees) {
     context_heading.lineTo(x_position, 53);
     context_heading.stroke();
   }
-}
 
-function draw_indicator_heading(context_heading) {
+  // Draw number showing the numerical value of the heading
+  context_heading.font = '18px Arial';
+  context_heading.fillText(degrees.toFixed(0), width_half, 100);
+
   // Draw a triangle indicating the heading
   context_heading.beginPath();
-  context_heading.moveTo(400, 58);
-  context_heading.lineTo(403, 68);
-  context_heading.lineTo(397, 68);
-  context_heading.lineTo(400, 58);
+  context_heading.moveTo(width_half, 58);
+  context_heading.lineTo(width_half + 3, 68);
+  context_heading.lineTo(width_half - 3, 68);
+  context_heading.lineTo(width_half, 58);
   context_heading.stroke();
   context_heading.fill();
 }

--- a/src/VideoComponents/js/tools.js
+++ b/src/VideoComponents/js/tools.js
@@ -1,0 +1,6 @@
+// Function for clamping a value between a minimum and maximum value
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+export { clamp };


### PR DESCRIPTION
Fixed several issues with the overlay widgets:
- Widgets will no longer resize (this caused bad resolution when scaling up)
- The heading widget is now centered on top of the screen
- Depth and bias values are now clamped, so as to avoid bad drawing in case of erroneous values
- Canvas sizes are corrected to better fit the window
- Optimized drawing of the bias widgets (they were previously drawn twice on top of each other)
Also added a feature:
- Depth and heading widgets now display their numerical values