### PR TITLE
Feature/minimap widget

### DIFF
--- a/src/VideoComponents/MiniMapWidget.jsx
+++ b/src/VideoComponents/MiniMapWidget.jsx
@@ -3,93 +3,203 @@ import PropTypes from 'prop-types';
 import './css/MiniMapWidget.css';
 import { mapRange } from './js/tools.js';
 
-export default function MiniMapWidget(props) {
-  const angle = Math.atan2(props.north, props.east); //calculates direction of the ROV based on north and east props
+function drawBoat(ctx, boatWidth, boatLength) {
+  ctx.beginPath();
+  ctx.moveTo(0, -boatLength / 2);
+  ctx.lineTo(boatWidth, -boatWidth);
+  ctx.lineTo(boatWidth, boatLength / 2);
+  ctx.lineTo(-boatWidth, boatLength / 2);
+  ctx.lineTo(-boatWidth, -boatWidth);
+  ctx.closePath();
+  ctx.fillStyle = '#FFFFFF';
+  ctx.fill();
+}
 
-  const boatAngle = useState(0); //radians
-  const ROVdirection = useState(angle); //radians
+function drawROV(ctx, rovSize) {
+  ctx.beginPath();
+  ctx.moveTo(-rovSize / 2, -rovSize / 2);
+  ctx.lineTo(rovSize / 2, -rovSize / 2);
+  ctx.lineTo(rovSize / 2, rovSize / 2);
+  ctx.lineTo(-rovSize / 2, rovSize / 2);
+  ctx.lineTo(-rovSize / 2, -rovSize / 2);
+  ctx.moveTo(0, -rovSize / 2);
+  ctx.lineTo(rovSize / 3, -rovSize / 3 - rovSize / 2);
+  ctx.lineTo(-rovSize / 3, -rovSize / 3 - rovSize / 2);
+  ctx.closePath();
+}
+
+function drawNEDframe(ctx, mapWidth, boatWidth, rovSize) {
+  ctx.beginPath();
+  //east arrow
+  ctx.moveTo(0, 0);
+  ctx.lineTo(mapWidth / 2 - boatWidth - rovSize / 2, 0);
+  ctx.lineTo(
+    mapWidth / 2 - boatWidth - rovSize / 2 - mapWidth / 40,
+    mapWidth / 40,
+  );
+  ctx.moveTo(mapWidth / 2 - boatWidth - rovSize / 2, 0);
+  ctx.lineTo(
+    mapWidth / 2 - boatWidth - rovSize / 2 - mapWidth / 40,
+    -mapWidth / 40,
+  );
+  //nort arrow
+  ctx.moveTo(0, 0);
+  ctx.lineTo(0, -(mapWidth / 2 - boatWidth - rovSize / 2));
+  ctx.lineTo(
+    -mapWidth / 40,
+    -(mapWidth / 2 - boatWidth - rovSize / 2) + mapWidth / 40,
+  );
+  ctx.moveTo(0, -(mapWidth / 2 - boatWidth - rovSize / 2));
+  ctx.lineTo(
+    mapWidth / 40,
+    -(mapWidth / 2 - boatWidth - rovSize / 2) + mapWidth / 40,
+  );
+  ctx.stroke();
+
+  ctx.strokeText(
+    'N',
+    mapWidth / 40,
+    -(mapWidth / 2 - boatWidth - rovSize / 2) + mapWidth / 40,
+  );
+  ctx.strokeText(
+    'E',
+    mapWidth / 2 - boatWidth - rovSize - mapWidth / 40,
+    mapWidth / 15,
+  );
+}
+
+function drawArrow(ctx, rovSize, mapWidth) {
+  ctx.beginPath();
+  ctx.moveTo(mapWidth / 2, 0);
+  ctx.lineTo(mapWidth / 2 - rovSize, rovSize);
+  ctx.lineTo(mapWidth / 2 - rovSize, -rovSize);
+  ctx.closePath();
+}
+
+export default function MiniMapWidget(props) {
+  const [boatHeading, setBoatHeading] = useState(0); //radians
+  const [maxDist, setMaxDist] = useState(props.maxDist); //metres, largest value of north or east that will draw the ROV as a square within the map's boundary
+  const boatHeadingOffset = useRef(0); //will store the initial boat heading
 
   const canvasRef = useRef();
-  const mapRadius = 100; //px
+  const mapWidth = 200; //px
   const rovSize = 15; //px
-  const maxDist = 5; //metres, largest value of north or east that will draw the ROV as a square within the map's boundary
+  const boatWidth = 20; //px
+  const boatLength = 80; //px
+
+  const firstUpdate = useRef(true);
 
   useEffect(() => {
+    const ROVangleInNED = Math.atan2(props.north, props.east); //calculates direction of the ROV based on north and east props
+    const leftSpace = mapWidth + boatWidth; //pixels to the left of where ROV when N, E = 0, 0
+    const rightSpace = mapWidth - boatWidth - rovSize; //pixels to the right of where ROV when N, E = 0, 0
+    const leftFactor = leftSpace / rightSpace; //describes how large portion of the map is left of the ROV when N, E = 0, 0
+    const rightFactor = rightSpace / leftSpace; //describes how large portion of the map is right of the ROV when N, E = 0, 0
+
+    if (firstUpdate.current) {
+      //happens on first render of component
+      firstUpdate.current = false;
+      boatHeadingOffset.current = props.boatHeading;
+    }
+    setBoatHeading(props.boatHeading - boatHeadingOffset.current); //set boatHeading to difference in heading since beginning
+
     const canvas = canvasRef.current;
     const ctx = canvas.getContext('2d');
+    ctx.clearRect(0, 0, mapWidth, mapWidth); //clear canvas to avoid drawing on top of previous canvas
 
     //draw map boundary
     ctx.beginPath();
-    ctx.arc(mapRadius + 1, mapRadius + 1, mapRadius, 0, 2 * Math.PI); //+1 so the circle's sides don't get cut by the canvas
+    ctx.rect(0, 0, mapWidth, mapWidth);
     ctx.strokeStyle = '#FFFFFF';
     ctx.stroke();
 
     //draw boat
     ctx.save(); //save context state so we can draw boat and ROV from different origins and rotate independently
-    ctx.translate(mapRadius, mapRadius); //draw boat from the middle of the circle
-    ctx.rotate(boatAngle[0]); //rotates the boat drawing about the middle of the circle
-    ctx.beginPath();
-    ctx.moveTo(0, -40);
-    ctx.lineTo(20, -20);
-    ctx.lineTo(20, 40);
-    ctx.lineTo(-20, 40);
-    ctx.lineTo(-20, -20);
-    ctx.closePath();
-    ctx.fillStyle = '#FFFFFF';
-    ctx.fill();
+    ctx.translate(mapWidth / 2, mapWidth / 2); //draw boat from the middle of the circle
+    //ctx.rotate(boatAngle[0]); //rotates the boat drawing about the middle of the circle
+    drawBoat(ctx, boatWidth, boatLength);
     ctx.restore(); //restore context state we saved earlier
 
+    const inBoundsEast =
+      props.east <= maxDist * rightFactor &&
+      props.east >= -maxDist * leftFactor; //multiply by left/rightFactor so the ROV square won't be replaced by arrow too early or late
+    const inBoundsNorth = Math.abs(props.north) <= maxDist;
     //draw ROV
-    if (Math.abs(props.east) <= maxDist && Math.abs(props.north) <= maxDist) {
-      //draw ROV as a square within the map
+    ctx.save();
+    ctx.translate(mapWidth / 2, mapWidth / 2);
+    ctx.rotate(-boatHeading); //rotates ROV around boat when boat rotates
 
+    if (inBoundsEast && inBoundsNorth) {
+      //draw ROV as a square within the map
       const mapNorth = mapRange(
         props.north,
         -maxDist,
         maxDist,
-        -mapRadius,
-        mapRadius,
+        -mapWidth / 2,
+        mapWidth / 2,
       ); //map north prop to the pixel range we're working with
       const mapEast = mapRange(
         props.east,
         -maxDist,
         maxDist,
-        -mapRadius,
-        mapRadius,
+        -mapWidth / 2,
+        mapWidth / 2,
       ); //map east prop to the pixel range we're working with
-
-      ctx.translate(
-        mapRadius + mapEast * Math.abs(Math.cos(angle)),
-        mapRadius - mapNorth * Math.abs(Math.sin(angle)),
-      ); //draw square at correct point in the map
-      ctx.beginPath();
-      ctx.moveTo(-rovSize / 2, -rovSize / 2);
-      ctx.lineTo(rovSize / 2, -rovSize / 2);
-      ctx.lineTo(rovSize / 2, rovSize / 2);
-      ctx.lineTo(-rovSize / 2, rovSize / 2);
-      ctx.closePath();
+      ctx.save();
+      ctx.translate(boatWidth + mapEast + rovSize / 2, -mapNorth); //draw square at correct point in the map
+      ctx.rotate(props.yaw);
+      drawROV(ctx, rovSize);
+      ctx.restore();
     } else {
       //draw arrow pointing to where the ROV is outside the map
-      ctx.translate(mapRadius, mapRadius); //origin in middle of map so we can rotate arrow about this point
-      ctx.rotate(-ROVdirection[0]); //point/rotate arrow in direction of ROV
-      ctx.beginPath();
-      ctx.moveTo(mapRadius, 0);
-      ctx.lineTo(mapRadius - rovSize, rovSize);
-      ctx.lineTo(mapRadius - rovSize, -rovSize);
-      ctx.closePath();
+      ctx.save();
+      ctx.translate(0, 0); //origin in middle of map so we can rotate arrow about this point
+      ctx.rotate(-ROVangleInNED); //point/rotate arrow in direction of ROV
+      drawArrow(
+        ctx,
+        rovSize *
+          (maxDist /
+            Math.log(
+              Math.exp(maxDist) +
+                Math.pow(Math.max(props.east, props.north), 3),
+            )),
+        mapWidth,
+      ); //make size of arrow based on how far out of bounds the ROV is
+      ctx.restore();
     }
     ctx.fillStyle = '#00FF00';
     ctx.fill();
-  });
+
+    ctx.translate(boatWidth + rovSize / 2, 0);
+    drawNEDframe(ctx, mapWidth, boatWidth, rovSize);
+    ctx.restore();
+  }, [props.boatHeading, props.east, props.north, props.yaw]);
+
+  /*
+  function zoomOut() {
+    if (maxDist < 1000) {
+      setMaxDist(maxDist + 1);
+    }
+  }
+
+  function zoomIn() {
+    if (maxDist > 1) {
+      setMaxDist(maxDist - 1);
+    }
+  }
+  */
 
   return (
-    <div className="MiniMap">
-      <canvas
-        ref={canvasRef}
-        width={2 * mapRadius + 2}
-        height={2 * mapRadius + 2}
-      />
-      {/*+2 to allow for map boundary to fit in canvas without clipping*/}
+    <div className="MiniMapWidget">
+      <div className="MiniMap">
+        <canvas ref={canvasRef} width={mapWidth} height={mapWidth} />
+      </div>
+      {/* these buttons let us increase or decrease the max distance that draws the ROV as a square on the map
+      <div className="zoom">
+        <button onClick={zoomOut}>-</button>  
+        <button onClick={zoomIn}>+</button>
+      </div>
+      */}
     </div>
   );
 }
@@ -97,4 +207,7 @@ export default function MiniMapWidget(props) {
 MiniMapWidget.propTypes = {
   north: PropTypes.number,
   east: PropTypes.number,
+  yaw: PropTypes.number,
+  boatHeading: PropTypes.number,
+  maxDist: PropTypes.number,
 };

--- a/src/VideoComponents/MiniMapWidget.jsx
+++ b/src/VideoComponents/MiniMapWidget.jsx
@@ -173,33 +173,40 @@ export default function MiniMapWidget(props) {
     ctx.translate(boatWidth + rovSize / 2, 0);
     drawNEDframe(ctx, mapWidth, boatWidth, rovSize);
     ctx.restore();
-  }, [props.boatHeading, props.east, props.north, props.yaw]);
+  }, [
+    props.boatHeading,
+    props.east,
+    props.north,
+    props.yaw,
+    maxDist,
+    boatHeading,
+  ]);
 
-  /*
   function zoomOut() {
     if (maxDist < 1000) {
+      //maximum 1000 metres
       setMaxDist(maxDist + 1);
     }
   }
 
   function zoomIn() {
     if (maxDist > 1) {
+      //minimum 1 metre
       setMaxDist(maxDist - 1);
     }
   }
-  */
 
   return (
     <div className="MiniMapWidget">
       <div className="MiniMap">
         <canvas ref={canvasRef} width={mapWidth} height={mapWidth} />
       </div>
-      {/* these buttons let us increase or decrease the max distance that draws the ROV as a square on the map
+      {/* these buttons let us increase or decrease the max distance 
+      that draws the ROV as a square on the map*/}
       <div className="zoom">
-        <button onClick={zoomOut}>-</button>  
+        <button onClick={zoomOut}>-</button>
         <button onClick={zoomIn}>+</button>
       </div>
-      */}
     </div>
   );
 }

--- a/src/VideoComponents/MiniMapWidget.jsx
+++ b/src/VideoComponents/MiniMapWidget.jsx
@@ -1,0 +1,100 @@
+import React, { useState, useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
+import './css/MiniMapWidget.css';
+import { mapRange } from './js/tools.js';
+
+export default function MiniMapWidget(props) {
+  const angle = Math.atan2(props.north, props.east); //calculates direction of the ROV based on north and east props
+
+  const boatAngle = useState(0); //radians
+  const ROVdirection = useState(angle); //radians
+
+  const canvasRef = useRef();
+  const mapRadius = 100; //px
+  const rovSize = 15; //px
+  const maxDist = 5; //metres, largest value of north or east that will draw the ROV as a square within the map's boundary
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const ctx = canvas.getContext('2d');
+
+    //draw map boundary
+    ctx.beginPath();
+    ctx.arc(mapRadius + 1, mapRadius + 1, mapRadius, 0, 2 * Math.PI); //+1 so the circle's sides don't get cut by the canvas
+    ctx.strokeStyle = '#FFFFFF';
+    ctx.stroke();
+
+    //draw boat
+    ctx.save(); //save context state so we can draw boat and ROV from different origins and rotate independently
+    ctx.translate(mapRadius, mapRadius); //draw boat from the middle of the circle
+    ctx.rotate(boatAngle[0]); //rotates the boat drawing about the middle of the circle
+    ctx.beginPath();
+    ctx.moveTo(0, -40);
+    ctx.lineTo(20, -20);
+    ctx.lineTo(20, 40);
+    ctx.lineTo(-20, 40);
+    ctx.lineTo(-20, -20);
+    ctx.closePath();
+    ctx.fillStyle = '#FFFFFF';
+    ctx.fill();
+    ctx.restore(); //restore context state we saved earlier
+
+    //draw ROV
+    if (Math.abs(props.east) <= maxDist && Math.abs(props.north) <= maxDist) {
+      //draw ROV as a square within the map
+
+      const mapNorth = mapRange(
+        props.north,
+        -maxDist,
+        maxDist,
+        -mapRadius,
+        mapRadius,
+      ); //map north prop to the pixel range we're working with
+      const mapEast = mapRange(
+        props.east,
+        -maxDist,
+        maxDist,
+        -mapRadius,
+        mapRadius,
+      ); //map east prop to the pixel range we're working with
+
+      ctx.translate(
+        mapRadius + mapEast * Math.abs(Math.cos(angle)),
+        mapRadius - mapNorth * Math.abs(Math.sin(angle)),
+      ); //draw square at correct point in the map
+      ctx.beginPath();
+      ctx.moveTo(-rovSize / 2, -rovSize / 2);
+      ctx.lineTo(rovSize / 2, -rovSize / 2);
+      ctx.lineTo(rovSize / 2, rovSize / 2);
+      ctx.lineTo(-rovSize / 2, rovSize / 2);
+      ctx.closePath();
+    } else {
+      //draw arrow pointing to where the ROV is outside the map
+      ctx.translate(mapRadius, mapRadius); //origin in middle of map so we can rotate arrow about this point
+      ctx.rotate(-ROVdirection[0]); //point/rotate arrow in direction of ROV
+      ctx.beginPath();
+      ctx.moveTo(mapRadius, 0);
+      ctx.lineTo(mapRadius - rovSize, rovSize);
+      ctx.lineTo(mapRadius - rovSize, -rovSize);
+      ctx.closePath();
+    }
+    ctx.fillStyle = '#00FF00';
+    ctx.fill();
+  });
+
+  return (
+    <div className="MiniMap">
+      <canvas
+        ref={canvasRef}
+        width={2 * mapRadius + 2}
+        height={2 * mapRadius + 2}
+      />
+      {/*+2 to allow for map boundary to fit in canvas without clipping*/}
+    </div>
+  );
+}
+
+MiniMapWidget.propTypes = {
+  north: PropTypes.number,
+  east: PropTypes.number,
+};

--- a/src/VideoComponents/VideoApp.jsx
+++ b/src/VideoComponents/VideoApp.jsx
@@ -50,6 +50,9 @@ function VideoApp() {
       <MiniMapWidget
         north={sensorValues['north']}
         east={sensorValues['east']}
+        yaw={sensorValues['yaw']}
+        boatHeading={0}
+        maxDist={5}
       />
 >>>>>>> #77 #81 feature: add simple minimap widget
       <VideoFeed />

--- a/src/VideoComponents/VideoApp.jsx
+++ b/src/VideoComponents/VideoApp.jsx
@@ -6,11 +6,8 @@ import HeadingWidget from './HeadingWidget';
 import DepthWidget from './DepthWidget';
 import './css/VideoApp.css';
 import VideoFeed from './VideoFeed';
-<<<<<<< HEAD
 import ModeWidget, { ModeEnum } from './ModeWidget';
-=======
 import MiniMapWidget from './MiniMapWidget';
->>>>>>> #77 #81 feature: add simple minimap widget
 
 const { remote } = window.require('electron');
 
@@ -44,9 +41,7 @@ function VideoApp() {
         isLocked={settingsValues['autodepth']}
         lockedValue={settingsValues['heave']}
       />
-<<<<<<< HEAD
       <ModeWidget mode={ModeEnum.NETFOLLOWING} nfavailable={true} />
-=======
       <MiniMapWidget
         north={sensorValues['north']}
         east={sensorValues['east']}
@@ -54,7 +49,6 @@ function VideoApp() {
         boatHeading={0}
         maxDistance={5}
       />
->>>>>>> #77 #81 feature: add simple minimap widget
       <VideoFeed />
     </div>
   );

--- a/src/VideoComponents/VideoApp.jsx
+++ b/src/VideoComponents/VideoApp.jsx
@@ -52,7 +52,7 @@ function VideoApp() {
         east={sensorValues['east']}
         yaw={sensorValues['yaw']}
         boatHeading={0}
-        maxDist={5}
+        maxDistance={5}
       />
 >>>>>>> #77 #81 feature: add simple minimap widget
       <VideoFeed />

--- a/src/VideoComponents/VideoApp.jsx
+++ b/src/VideoComponents/VideoApp.jsx
@@ -6,7 +6,11 @@ import HeadingWidget from './HeadingWidget';
 import DepthWidget from './DepthWidget';
 import './css/VideoApp.css';
 import VideoFeed from './VideoFeed';
+<<<<<<< HEAD
 import ModeWidget, { ModeEnum } from './ModeWidget';
+=======
+import MiniMapWidget from './MiniMapWidget';
+>>>>>>> #77 #81 feature: add simple minimap widget
 
 const { remote } = window.require('electron');
 
@@ -40,7 +44,14 @@ function VideoApp() {
         isLocked={settingsValues['autodepth']}
         lockedValue={settingsValues['heave']}
       />
+<<<<<<< HEAD
       <ModeWidget mode={ModeEnum.NETFOLLOWING} nfavailable={true} />
+=======
+      <MiniMapWidget
+        north={sensorValues['north']}
+        east={sensorValues['east']}
+      />
+>>>>>>> #77 #81 feature: add simple minimap widget
       <VideoFeed />
     </div>
   );

--- a/src/VideoComponents/css/MiniMapWidget.css
+++ b/src/VideoComponents/css/MiniMapWidget.css
@@ -6,6 +6,11 @@
     padding-top: 100px;
 }
 
+.zoom {
+    display: flex;
+    flex-direction: column;
+}
+
 .zoom > button {
     background: black;
     color: white;

--- a/src/VideoComponents/css/MiniMapWidget.css
+++ b/src/VideoComponents/css/MiniMapWidget.css
@@ -1,5 +1,15 @@
-.MiniMap {
-    position: absolute;
-    right: 270px;
-    top: 100px;
+.MiniMapWidget {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    padding-right: 270px;
+    padding-top: 100px;
+}
+
+.zoom > button {
+    background: black;
+    color: white;
+    border: 1px solid gray;
+    cursor: pointer;
+    font-size: 20px;
 }

--- a/src/VideoComponents/css/MiniMapWidget.css
+++ b/src/VideoComponents/css/MiniMapWidget.css
@@ -2,8 +2,9 @@
     display: flex;
     flex-direction: column;
     align-items: flex-end;
-    padding-right: 270px;
-    padding-top: 100px;
+    position: absolute;
+    top: 100px;
+    right: 270px;
 }
 
 .zoom {
@@ -12,9 +13,9 @@
 }
 
 .zoom > button {
-    background: black;
+    background: transparent;
     color: white;
-    border: 1px solid gray;
+    border: 0.5px solid white;
     cursor: pointer;
     font-size: 20px;
 }

--- a/src/VideoComponents/css/MiniMapWidget.css
+++ b/src/VideoComponents/css/MiniMapWidget.css
@@ -8,6 +8,7 @@
 }
 
 .zoom {
+    z-index: 1;
     display: flex;
     flex-direction: column;
 }

--- a/src/VideoComponents/css/MiniMapWidget.css
+++ b/src/VideoComponents/css/MiniMapWidget.css
@@ -1,0 +1,5 @@
+.MiniMap {
+    position: absolute;
+    right: 270px;
+    top: 100px;
+}

--- a/src/VideoComponents/js/minimap.js
+++ b/src/VideoComponents/js/minimap.js
@@ -1,0 +1,84 @@
+import { radiansToDegrees } from './tools.js';
+
+function drawBoat(ctx, boatWidth, boatLength, boatHeading) {
+  const boatDegrees = radiansToDegrees(boatHeading);
+  ctx.beginPath();
+  ctx.moveTo(0, -boatLength / 2);
+  ctx.lineTo(0, (-2 * boatLength) / 3);
+  ctx.font = '13px Arial';
+  ctx.textAlign = 'center';
+  ctx.strokeText(boatDegrees.toFixed(0) + '\xB0', 0, (-2 * boatLength) / 2.5);
+  ctx.lineTo(0, -boatLength / 2);
+  ctx.lineTo(boatWidth, -boatWidth);
+  ctx.lineTo(boatWidth, boatLength / 2);
+  ctx.lineTo(-boatWidth, boatLength / 2);
+  ctx.lineTo(-boatWidth, -boatWidth);
+  ctx.closePath();
+  ctx.fillStyle = '#FFFFFF';
+  ctx.strokeStyle = '#FFFFFF';
+  ctx.fill();
+  ctx.stroke();
+}
+
+function drawROV(ctx, rovSize) {
+  ctx.beginPath();
+  ctx.moveTo(-rovSize / 2, -rovSize / 2);
+  ctx.lineTo(rovSize / 2, -rovSize / 2);
+  ctx.lineTo(rovSize / 2, rovSize / 2);
+  ctx.lineTo(-rovSize / 2, rovSize / 2);
+  ctx.lineTo(-rovSize / 2, -rovSize / 2);
+  ctx.moveTo(0, -rovSize / 2);
+  ctx.lineTo(rovSize / 3, -rovSize / 3 - rovSize / 2);
+  ctx.lineTo(-rovSize / 3, -rovSize / 3 - rovSize / 2);
+  ctx.closePath();
+}
+
+function drawNEDframe(ctx, mapWidth, boatWidth, rovSize) {
+  ctx.beginPath();
+  //east arrow
+  ctx.moveTo(0, 0);
+  ctx.lineTo(mapWidth / 2 - boatWidth - rovSize / 2, 0);
+  ctx.lineTo(
+    mapWidth / 2 - boatWidth - rovSize / 2 - mapWidth / 40,
+    mapWidth / 40,
+  );
+  ctx.moveTo(mapWidth / 2 - boatWidth - rovSize / 2, 0);
+  ctx.lineTo(
+    mapWidth / 2 - boatWidth - rovSize / 2 - mapWidth / 40,
+    -mapWidth / 40,
+  );
+  //nort arrow
+  ctx.moveTo(0, 0);
+  ctx.lineTo(0, -(mapWidth / 2 - boatWidth - rovSize / 2));
+  ctx.lineTo(
+    -mapWidth / 40,
+    -(mapWidth / 2 - boatWidth - rovSize / 2) + mapWidth / 40,
+  );
+  ctx.moveTo(0, -(mapWidth / 2 - boatWidth - rovSize / 2));
+  ctx.lineTo(
+    mapWidth / 40,
+    -(mapWidth / 2 - boatWidth - rovSize / 2) + mapWidth / 40,
+  );
+  ctx.stroke();
+
+  ctx.strokeText(
+    'N',
+    mapWidth / 40,
+    -(mapWidth / 2 - boatWidth - rovSize / 2) + mapWidth / 40,
+  );
+  ctx.strokeText(
+    'E',
+    mapWidth / 2 - boatWidth - rovSize - mapWidth / 40,
+    mapWidth / 15,
+  );
+}
+
+function drawArrow(ctx, rovSize, mapWidth) {
+  ctx.beginPath();
+  ctx.moveTo(mapWidth / 2, 0);
+  ctx.lineTo(mapWidth / 2 - rovSize, rovSize);
+  ctx.lineTo(mapWidth / 2 - rovSize, -rovSize);
+  ctx.closePath();
+}
+
+export { drawBoat, drawROV, drawNEDframe, drawArrow };


### PR DESCRIPTION
This implementation of the minimap makes the following assumptions:

- The ROV is placed on starboard side of the boat with the same heading as the boat

- The origin of the NED-frame stays in this position

- The boat's latitude and longitude does not change



The ROV is drawn on the minimap as a square if the absolute values of north and east are less than maxDist (although not exactly because on the map there is less space on the right side where the ROV is initially because the map is centered on the boat).

The maxDist can be changed with buttons (- and +). If we don't want to click on buttons on the videowindow, maxDist could be made to change automatically. Maybe maxDist should be kept static but at an appropriate value?

If north or east is too large, an arrow pointing in the direction of the ROV outside the map is shown.

If the direction of the boat changes after first render of the component the NED-frame will rotate around the boat accordingly.

Would be nice if someone with a controller could test if this acts as it should.