### PR TITLE
feature/imc

### DIFF
--- a/public/TCP/IMC.js
+++ b/public/TCP/IMC.js
@@ -185,11 +185,9 @@ function UIntBEToBitfield(uint, metadataFields) {
 }
 
 function lenImcMessage(message) {
-  let len = 0;
-  message.map(a => {
-    len += a.datatype.length;
-  });
-  return len;
+  return message.reduce((acc, field) => {
+    return acc + field.datatype.length;
+  }, 0);
 }
 
 const estimatedStateMetadata = {
@@ -491,7 +489,7 @@ const customNetFollowStateMetadata = {
       datatype: datatypes.fp32_t,
     },
     {
-      name: 'rad',
+      name: 'angle',
       datatype: datatypes.fp64_t,
     },
   ],

--- a/public/TCP/IMC.js
+++ b/public/TCP/IMC.js
@@ -1,3 +1,17 @@
+const {
+  datatypes,
+  customNetFollowStateMetadata,
+  estimatedStateMetadata,
+  entityStateMetadata,
+  desiredControlMetadata,
+  lowLevelControlManeuverMetadata,
+  desiredHeadingMetadata,
+  desiredZMetadata,
+  goToMetadata,
+  netFollowMetadata,
+  messages,
+} = require('./IMCMetadata');
+
 const encode = {
   estimatedState: encodeEstimatedState,
   entityState: encodeEntityState,
@@ -12,6 +26,11 @@ const encode = {
 };
 
 function decode(buf) {
+  /**
+   * Decodes a Buffer with possibly multiple IMC messages
+   *
+   * Return an object of this type: {'entityState': {...}, 'estimatedState': ...}
+   */
   let result = {};
   let offset = 0;
   let msg, name;
@@ -21,51 +40,6 @@ function decode(buf) {
   } while (offset < buf.length);
   return result;
 }
-
-const messages = {
-  estimatedState: 'estimatedState',
-  entityState: 'entityState',
-  desiredControl: 'desiredControl',
-  desiredHeading: 'desiredHeading',
-  desiredZ: 'desiredZ',
-  lowLevelControlManeuver: {
-    desiredHeading: 'lowLevelControlManeuver.desiredHeading',
-    desiredZ: 'lowLevelControlManeuver.desiredZ',
-  },
-  goTo: 'goTo',
-  netFollow: 'netFollow',
-  customNetFollowState: 'customNetFollowState',
-};
-
-const datatypes = {
-  uint_8t: {
-    name: 'uint_8t',
-    length: 1,
-  },
-  uint_16t: {
-    name: 'uint_16t',
-    length: 2,
-  },
-  uint_32t: {
-    name: 'uint_16t',
-    length: 4,
-  },
-  fp32_t: {
-    name: 'fp32_t',
-    length: 4,
-  },
-  fp64_t: {
-    name: 'fp64_t',
-    length: 8,
-  },
-  bitfield: {
-    name: 'bitfield',
-    length: 1,
-  },
-  recursive: {
-    name: 'recursive',
-  },
-};
 
 function encodeIMC(imcMessage, imcMessageMetadata) {
   // Check if assumed length is corret
@@ -124,11 +98,11 @@ function encodeIMC(imcMessage, imcMessageMetadata) {
 }
 
 function decodeImc(buf, offset = 0, name = '') {
-  const result = {};
+  let result = {};
 
   // Get information from id
-  let id = buf.readUInt16BE(offset);
-  let imcMessageMetadata = idToMessageMetadata[id];
+  const id = buf.readUInt16BE(offset);
+  const imcMessageMetadata = idToMessageMetadata[id];
   if (name) name += '.';
   name += imcMessageMetadata.name;
   offset += 2;
@@ -180,8 +154,7 @@ function bitfieldToUIntBE(values, metadataFieldsArray) {
    * `metadataFieldsArray` is an array with name of field. I.e. ['NF', 'DP, '', ...]
    */
   let bitfield = 0x00000000;
-  let keys = Object.keys(values);
-  keys.map(key => {
+  Object.keys(values).map(key => {
     if (values[key]) {
       let idx =
         metadataFieldsArray.length - (metadataFieldsArray.indexOf(key) + 1);
@@ -191,14 +164,18 @@ function bitfieldToUIntBE(values, metadataFieldsArray) {
   return bitfield;
 }
 
-function UIntBEToBitfield(uint, metadataFields) {
+function UIntBEToBitfield(uint, metadataFieldsArray) {
+  /**
+   * `uint` should be an integer between 0 and 255 (8 bits)
+   * `metadataFieldsArray` is an array with name of field. I.e. ['NF', 'DP, '', ...]
+   *
+   * Returns an object of this type: {'NF': true, 'DP': false}
+   */
   let result = {};
-  // console.log(`Recieved bitfield: ${uint}`);
-
-  metadataFields.map((feild, i) => {
+  metadataFieldsArray.map((feild, i) => {
     if (feild) {
-      result[feild] = ((1 << (metadataFields.length - (i + 1))) & uint) !== 0;
-      // console.log(dec2bin(1 << (metadataFields.length - (i + 1))));
+      result[feild] =
+        ((1 << (metadataFieldsArray.length - (i + 1))) & uint) !== 0;
     }
   });
   return result;
@@ -210,128 +187,17 @@ function lenImcMessage(message) {
   }, 0);
 }
 
-const estimatedStateMetadata = {
-  name: messages.estimatedState,
-  length: 90,
-  id: {
-    value: 350,
-    datatype: datatypes.uint_16t,
-  },
-  message: [
-    { name: 'lat', datatype: datatypes.fp64_t },
-    { name: 'lon', datatype: datatypes.fp64_t },
-    { name: 'height', datatype: datatypes.fp32_t },
-    { name: 'x', datatype: datatypes.fp32_t },
-    { name: 'y', datatype: datatypes.fp32_t },
-    { name: 'z', datatype: datatypes.fp32_t },
-    { name: 'phi', datatype: datatypes.fp32_t },
-    { name: 'theta', datatype: datatypes.fp32_t },
-    { name: 'psi', datatype: datatypes.fp32_t },
-    { name: 'u', datatype: datatypes.fp32_t },
-    { name: 'v', datatype: datatypes.fp32_t },
-    { name: 'w', datatype: datatypes.fp32_t },
-    { name: 'vx', datatype: datatypes.fp32_t },
-    { name: 'vy', datatype: datatypes.fp32_t },
-    { name: 'vz', datatype: datatypes.fp32_t },
-    { name: 'p', datatype: datatypes.fp32_t },
-    { name: 'q', datatype: datatypes.fp32_t },
-    { name: 'r', datatype: datatypes.fp32_t },
-    { name: 'depth', datatype: datatypes.fp32_t },
-    { name: 'alt', datatype: datatypes.fp32_t },
-  ],
-};
-
 function encodeEstimatedState(estimatedState) {
   return encodeIMC(estimatedState, estimatedStateMetadata);
 }
-
-const entityStateMetadata = {
-  name: messages.entityState,
-  length: 8,
-  id: {
-    value: 1,
-    datatype: datatypes.uint_16t,
-  },
-  message: [
-    { name: 'state', datatype: datatypes.uint_8t },
-    {
-      name: 'flags',
-      datatype: datatypes.bitfield,
-      fields: ['NF', 'DP', '', '', '', '', '', ''],
-    },
-    {
-      name: 'description',
-      datatype: datatypes.uint_32t,
-      value: 131072,
-    },
-  ],
-};
 
 function encodeEntityState(entityState) {
   return encodeIMC(entityState, entityStateMetadata);
 }
 
-const desiredControlMetadata = {
-  name: messages.desiredControl,
-  length: 51,
-  id: {
-    value: 407,
-    datatype: datatypes.uint_16t,
-  },
-  message: [
-    {
-      name: 'x',
-      datatype: datatypes.fp64_t,
-    },
-    {
-      name: 'y',
-      datatype: datatypes.fp64_t,
-    },
-    {
-      name: 'z',
-      datatype: datatypes.fp64_t,
-    },
-    {
-      name: 'k',
-      datatype: datatypes.fp64_t,
-    },
-    {
-      name: 'm',
-      datatype: datatypes.fp64_t,
-    },
-    {
-      name: 'n',
-      datatype: datatypes.fp64_t,
-    },
-    {
-      name: 'flags',
-      datatype: datatypes.bitfield,
-      fields: ['x', 'y', 'z', 'k', 'm', 'n', '', ''],
-    },
-  ],
-};
-
 function encodeDesiredControl(desiredControl) {
   return encodeIMC(desiredControl, desiredControlMetadata);
 }
-
-const lowLevelControlManeuverMetadata = {
-  name: 'lowLevelControlManeuver', // This must be treated seperablely because it encapsulates other messages
-  id: {
-    value: 455,
-    datatype: datatypes.uint_16t,
-  },
-  message: [
-    {
-      name: 'control',
-      datatype: datatypes.recursive,
-    },
-    {
-      name: 'duration',
-      datatype: datatypes.uint_16t,
-    },
-  ],
-};
 
 function encodeLowLevelControlManeuver(
   encodeControlManeuver,
@@ -352,21 +218,6 @@ function encodeLowLevelControlManeuver(
   );
 }
 
-const desiredHeadingMetadata = {
-  name: messages.desiredHeading,
-  length: 10,
-  id: {
-    value: 400,
-    datatype: datatypes.uint_16t,
-  },
-  message: [
-    {
-      name: 'value',
-      datatype: datatypes.fp64_t,
-    },
-  ],
-};
-
 function encodeDesiredHeading(desiredHeading) {
   return encodeIMC(desiredHeading, desiredHeadingMetadata);
 }
@@ -379,25 +230,6 @@ function encodeLowLevelControlManeuverDesiredHeading(desiredHeading, duration) {
   );
 }
 
-const desiredZMetadata = {
-  name: messages.desiredZ,
-  length: 7,
-  id: {
-    value: 401,
-    datatype: datatypes.uint_16t,
-  },
-  message: [
-    {
-      name: 'value',
-      datatype: datatypes.fp32_t,
-    },
-    {
-      name: 'z_units',
-      datatype: datatypes.uint_8t,
-    },
-  ],
-};
-
 function encodeDesiredZ(desiredZ) {
   return encodeIMC(desiredZ, desiredZMetadata);
 }
@@ -406,123 +238,13 @@ function encodeLowLevelControlManeuverDesiredZ(desiredZ, duration) {
   return encodeLowLevelControlManeuver(encodeDesiredZ, desiredZ, duration);
 }
 
-const goToMetadata = {
-  name: messages.goTo,
-  length: 54,
-  id: {
-    value: 450,
-    datatype: datatypes.uint_16t,
-  },
-  message: [
-    {
-      name: 'timeout',
-      datatype: datatypes.uint_16t,
-    },
-    {
-      name: 'lat',
-      datatype: datatypes.fp64_t,
-    },
-    {
-      name: 'lon',
-      datatype: datatypes.fp64_t,
-    },
-    {
-      name: 'z',
-      datatype: datatypes.fp32_t,
-    },
-    {
-      name: 'z_units',
-      datatype: datatypes.uint_8t,
-    },
-    {
-      name: 'speed',
-      datatype: datatypes.fp32_t,
-    },
-    {
-      name: 'speed_units',
-      datatype: datatypes.uint_8t,
-    },
-    {
-      name: 'roll',
-      datatype: datatypes.fp64_t,
-    },
-    {
-      name: 'pitch',
-      datatype: datatypes.fp64_t,
-    },
-    {
-      name: 'yaw',
-      datatype: datatypes.fp64_t,
-    },
-  ],
-};
-
 function encodeGoTo(goTo) {
   return encodeIMC(goTo, goToMetadata);
 }
 
-const netFollowMetadata = {
-  name: messages.netFollow,
-  length: 33,
-  id: {
-    value: 465,
-    datatype: datatypes.uint_16t,
-  },
-  message: [
-    {
-      name: 'timeout',
-      datatype: datatypes.uint_16t,
-    },
-    {
-      name: 'name',
-      datatype: datatypes.uint_32t,
-      value: 151110,
-    },
-    {
-      name: 'd',
-      datatype: datatypes.fp64_t,
-    },
-    {
-      name: 'v',
-      datatype: datatypes.fp64_t,
-    },
-    {
-      name: 'z',
-      datatype: datatypes.fp64_t,
-    },
-    {
-      name: 'z_units',
-      datatype: datatypes.uint_8t,
-    },
-  ],
-};
-
 function encodeNetFollow(netFollow) {
   return encodeIMC(netFollow, netFollowMetadata);
 }
-
-const customNetFollowStateMetadata = {
-  name: messages.customNetFollowState,
-  length: 18,
-  id: {
-    value: 1002,
-    datatype: datatypes.uint_16t,
-  },
-  message: [
-    {
-      name: 'd',
-      datatype: datatypes.fp32_t,
-    },
-    {
-      name: 'v',
-      datatype: datatypes.fp32_t,
-    },
-    {
-      name: 'angle',
-      datatype: datatypes.fp64_t,
-    },
-  ],
-};
 
 function encodeCustomNetFollowState(customNetFollowState) {
   return encodeIMC(customNetFollowState, customNetFollowStateMetadata);
@@ -540,4 +262,4 @@ const idToMessageMetadata = {
   1002: customNetFollowStateMetadata,
 };
 
-module.exports = { encode, decode };
+module.exports = { encode, decode, messages };

--- a/public/TCP/IMC.js
+++ b/public/TCP/IMC.js
@@ -1,0 +1,138 @@
+const encode = {
+  estimatedState: encodeEstimatedState,
+};
+
+const decode = {
+  estimatedState: decodeEstimatedState,
+};
+
+const datatypes = {
+  uint_16t: {
+    name: 'uint_16t',
+    length: 2,
+  },
+  fp32_t: {
+    name: 'fp32_t',
+    length: 4,
+  },
+  fp64_t: {
+    name: 'fp64_t',
+    length: 8,
+  },
+};
+
+function encodeIMC(imcMessage, imcMessageMetadata) {
+  // Check if assumed length is corret
+  console.log(
+    imcMessageMetadata.length,
+    lenImcMessage(imcMessageMetadata.message),
+  );
+
+  let buf = Buffer.alloc(imcMessageMetadata.length);
+
+  // Encode ID
+  buf.writeUInt16BE(imcMessageMetadata.id.value);
+
+  console.log(
+    imcMessageMetadata.id.datatype.length,
+    imcMessageMetadata.message[0].datatype.length,
+  );
+
+  let offset =
+    imcMessageMetadata.id.datatype.length -
+    imcMessageMetadata.message[0].datatype.length;
+
+  imcMessageMetadata.message.map(value => {
+    offset += value.datatype.length;
+    console.log(offset);
+
+    switch (value.datatype) {
+      case datatypes.uint_16t:
+        buf.writeUInt16BE(imcMessage[value['name']], offset);
+        break;
+      case datatypes.fp32_t:
+        buf.writeFloatBE(imcMessage[value['name']], offset);
+        break;
+      case datatypes.fp64_t:
+        buf.writeDoubleBE(imcMessage[value['name']], offset);
+        break;
+      default:
+        break;
+    }
+  });
+  return buf;
+}
+
+function decodeImc(buf, imcMessageMetadata) {
+  const result = {};
+  let offset =
+    imcMessageMetadata.id.datatype.length -
+    imcMessageMetadata.message[0].datatype.length;
+
+  imcMessageMetadata.message.map(value => {
+    offset += value.datatype.length;
+    switch (value.datatype) {
+      case datatypes.uint_16t:
+        result[value.name] = buf.readUInt16BE(offset);
+        break;
+      case datatypes.fp32_t:
+        result[value.name] = buf.readFloatBE(offset);
+        break;
+      case datatypes.fp64_t:
+        result[value.name] = buf.readDoubleBE(offset);
+        break;
+      default:
+        break;
+    }
+  });
+  return result;
+}
+
+function lenImcMessage(message) {
+  let len = 0;
+  message.map(a => {
+    len += a.datatype.length;
+    console.log(a);
+  });
+  return len;
+}
+
+const estimatedStateMetadata = {
+  length: 90,
+  id: {
+    value: 350,
+    datatype: datatypes.uint_16t,
+  },
+  message: [
+    { name: 'lat', datatype: datatypes.fp64_t },
+    { name: 'lon', datatype: datatypes.fp64_t },
+    { name: 'height', datatype: datatypes.fp32_t },
+    { name: 'x', datatype: datatypes.fp32_t },
+    { name: 'y', datatype: datatypes.fp32_t },
+    { name: 'z', datatype: datatypes.fp32_t },
+    { name: 'phi', datatype: datatypes.fp32_t },
+    { name: 'theta', datatype: datatypes.fp32_t },
+    { name: 'psi', datatype: datatypes.fp32_t },
+    { name: 'u', datatype: datatypes.fp32_t },
+    { name: 'v', datatype: datatypes.fp32_t },
+    { name: 'w', datatype: datatypes.fp32_t },
+    { name: 'vx', datatype: datatypes.fp32_t },
+    { name: 'vy', datatype: datatypes.fp32_t },
+    { name: 'vz', datatype: datatypes.fp32_t },
+    { name: 'p', datatype: datatypes.fp32_t },
+    { name: 'q', datatype: datatypes.fp32_t },
+    { name: 'r', datatype: datatypes.fp32_t },
+    { name: 'depth', datatype: datatypes.fp32_t },
+    { name: 'alt', datatype: datatypes.fp32_t },
+  ],
+};
+
+function encodeEstimatedState(estimatedState) {
+  return encodeIMC(estimatedState, estimatedStateMetadata);
+}
+
+function decodeEstimatedState(buf) {
+  return decodeImc(buf, estimatedStateMetadata);
+}
+
+module.exports = { encode, decode };

--- a/public/TCP/IMC.js
+++ b/public/TCP/IMC.js
@@ -192,10 +192,6 @@ function lenImcMessage(message) {
   return len;
 }
 
-function dec2bin(dec) {
-  return (dec >>> 0).toString(2);
-}
-
 const estimatedStateMetadata = {
   length: 90,
   id: {

--- a/public/TCP/IMC.test.js
+++ b/public/TCP/IMC.test.js
@@ -1,0 +1,144 @@
+const { encode, decode } = require('./IMC');
+
+// entityState ================================
+const states = {
+  manual: 0,
+  NF: 1,
+  DP: 2,
+};
+
+const entityState = {
+  state: states.manual,
+  flags: {
+    NF: false,
+    DP: true,
+  },
+};
+
+console.log('entityState ================================');
+
+console.log(entityState);
+
+let bufEntityState = encode.entityState(entityState);
+console.log(bufEntityState);
+
+let resultEntityState = decode(bufEntityState);
+console.log(resultEntityState);
+
+// entityState ================================
+
+// desiredControl =============================
+const desiredControl = {
+  x: 1.1,
+  y: 2.2,
+  z: 3.3,
+  k: 4.4,
+  m: 5.5,
+  n: 6.6,
+  flags: {
+    x: true,
+    y: true,
+    z: true,
+    k: true,
+    m: true,
+    n: false,
+  },
+};
+
+console.log('desiredControl =============================');
+console.log(desiredControl);
+
+let bufDesiredControl = encode.desiredControl(desiredControl);
+console.log(bufDesiredControl);
+
+let resultDesiredControl = decode(bufDesiredControl);
+console.log(resultDesiredControl);
+
+// desiredHeading =============================
+console.log('desiredHeading =============================');
+const desiredHeading = {
+  value: 3.14,
+};
+
+console.log(desiredHeading);
+
+let bufdesiredHeading = encode.lowLevelControlManeuver.desiredHeading(
+  desiredHeading,
+  10,
+);
+console.log(bufdesiredHeading);
+
+let resultdesiredHeading = decode(bufdesiredHeading);
+console.log(resultdesiredHeading);
+
+// desiredZ =============================
+console.log('desiredZ =============================');
+const desiredZ = {
+  value: 2.71828182846,
+  z_units: 3,
+};
+
+console.log(desiredZ);
+
+let bufDesiredZ = encode.lowLevelControlManeuver.desiredZ(desiredZ, 10);
+console.log(bufDesiredZ);
+
+let resultDesiredZ = decode(bufDesiredZ);
+console.log(resultDesiredZ);
+
+// goTo =============================
+console.log('goTo =============================');
+const goTo = {
+  timeout: 132,
+  lat: 1.1,
+  lon: 2.2,
+  z: 3.3,
+  z_units: 3,
+  speed: 4.4,
+  speed_units: 0,
+  roll: 5.5,
+  pitch: 6.6,
+  yaw: 7.7,
+};
+
+console.log(goTo);
+
+let bufGoTo = encode.goTo(goTo);
+console.log(bufGoTo);
+
+let resultGoTo = decode(bufGoTo);
+console.log(resultGoTo);
+
+// netFollow =============================
+console.log('netFollow =============================');
+const netFollow = {
+  timeout: 132,
+  d: 1.1,
+  v: 2.2,
+  z: 3.3,
+  z_units: 3,
+};
+
+console.log(netFollow);
+
+let bufnetFollow = encode.netFollow(netFollow);
+console.log(bufnetFollow);
+
+let resultnetFollow = decode(bufnetFollow);
+console.log(resultnetFollow);
+
+// customNetFollow =============================
+console.log('customNetFollow =============================');
+const customNetFollow = {
+  d: 132,
+  v: 1.1,
+  angle: 2.2,
+};
+
+console.log(customNetFollow);
+
+let bufcustomNetFollow = encode.customNetFollow(customNetFollow);
+console.log(bufcustomNetFollow);
+
+let resultcustomNetFollow = decode(bufcustomNetFollow);
+console.log(resultcustomNetFollow);

--- a/public/TCP/IMCMetadata.js
+++ b/public/TCP/IMCMetadata.js
@@ -1,0 +1,321 @@
+const messages = {
+  estimatedState: 'estimatedState',
+  entityState: 'entityState',
+  desiredControl: 'desiredControl',
+  desiredHeading: 'desiredHeading',
+  desiredZ: 'desiredZ',
+  lowLevelControlManeuver: {
+    desiredHeading: 'lowLevelControlManeuver.desiredHeading',
+    desiredZ: 'lowLevelControlManeuver.desiredZ',
+  },
+  goTo: 'goTo',
+  netFollow: 'netFollow',
+  customNetFollowState: 'customNetFollowState',
+};
+
+const datatypes = {
+  uint_8t: {
+    name: 'uint_8t',
+    length: 1,
+  },
+  uint_16t: {
+    name: 'uint_16t',
+    length: 2,
+  },
+  uint_32t: {
+    name: 'uint_16t',
+    length: 4,
+  },
+  fp32_t: {
+    name: 'fp32_t',
+    length: 4,
+  },
+  fp64_t: {
+    name: 'fp64_t',
+    length: 8,
+  },
+  bitfield: {
+    name: 'bitfield',
+    length: 1,
+  },
+  recursive: {
+    name: 'recursive',
+  },
+};
+
+const estimatedStateMetadata = {
+  // https://www.lsts.pt/docs/imc/imc-5.4.11/Navigation.html#estimated-state
+  name: messages.estimatedState,
+  length: 90,
+  id: {
+    value: 350,
+    datatype: datatypes.uint_16t,
+  },
+  message: [
+    { name: 'lat', datatype: datatypes.fp64_t },
+    { name: 'lon', datatype: datatypes.fp64_t },
+    { name: 'height', datatype: datatypes.fp32_t },
+    { name: 'x', datatype: datatypes.fp32_t },
+    { name: 'y', datatype: datatypes.fp32_t },
+    { name: 'z', datatype: datatypes.fp32_t },
+    { name: 'phi', datatype: datatypes.fp32_t },
+    { name: 'theta', datatype: datatypes.fp32_t },
+    { name: 'psi', datatype: datatypes.fp32_t },
+    { name: 'u', datatype: datatypes.fp32_t },
+    { name: 'v', datatype: datatypes.fp32_t },
+    { name: 'w', datatype: datatypes.fp32_t },
+    { name: 'vx', datatype: datatypes.fp32_t },
+    { name: 'vy', datatype: datatypes.fp32_t },
+    { name: 'vz', datatype: datatypes.fp32_t },
+    { name: 'p', datatype: datatypes.fp32_t },
+    { name: 'q', datatype: datatypes.fp32_t },
+    { name: 'r', datatype: datatypes.fp32_t },
+    { name: 'depth', datatype: datatypes.fp32_t },
+    { name: 'alt', datatype: datatypes.fp32_t },
+  ],
+};
+
+const entityStateMetadata = {
+  // https://www.lsts.pt/docs/imc/imc-5.4.11/Core.html#entity-state
+  name: messages.entityState,
+  length: 8,
+  id: {
+    value: 1,
+    datatype: datatypes.uint_16t,
+  },
+  message: [
+    { name: 'state', datatype: datatypes.uint_8t },
+    {
+      name: 'flags',
+      datatype: datatypes.bitfield,
+      fields: ['NF', 'DP', '', '', '', '', '', ''],
+    },
+    {
+      name: 'description',
+      datatype: datatypes.uint_32t,
+      value: 131072,
+    },
+  ],
+};
+
+const desiredControlMetadata = {
+  // https://www.lsts.pt/docs/imc/imc-5.4.11/Guidance.html#desired-control
+  name: messages.desiredControl,
+  length: 51,
+  id: {
+    value: 407,
+    datatype: datatypes.uint_16t,
+  },
+  message: [
+    {
+      name: 'x',
+      datatype: datatypes.fp64_t,
+    },
+    {
+      name: 'y',
+      datatype: datatypes.fp64_t,
+    },
+    {
+      name: 'z',
+      datatype: datatypes.fp64_t,
+    },
+    {
+      name: 'k',
+      datatype: datatypes.fp64_t,
+    },
+    {
+      name: 'm',
+      datatype: datatypes.fp64_t,
+    },
+    {
+      name: 'n',
+      datatype: datatypes.fp64_t,
+    },
+    {
+      name: 'flags',
+      datatype: datatypes.bitfield,
+      fields: ['x', 'y', 'z', 'k', 'm', 'n', '', ''],
+    },
+  ],
+};
+
+const desiredHeadingMetadata = {
+  // https://www.lsts.pt/docs/imc/imc-5.4.11/Guidance.html#desired-heading
+  name: messages.desiredHeading,
+  length: 10,
+  id: {
+    value: 400,
+    datatype: datatypes.uint_16t,
+  },
+  message: [
+    {
+      name: 'value',
+      datatype: datatypes.fp64_t,
+    },
+  ],
+};
+
+const desiredZMetadata = {
+  // https://www.lsts.pt/docs/imc/imc-5.4.11/Guidance.html#desired-z
+  name: messages.desiredZ,
+  length: 7,
+  id: {
+    value: 401,
+    datatype: datatypes.uint_16t,
+  },
+  message: [
+    {
+      name: 'value',
+      datatype: datatypes.fp32_t,
+    },
+    {
+      name: 'z_units',
+      datatype: datatypes.uint_8t,
+    },
+  ],
+};
+
+const lowLevelControlManeuverMetadata = {
+  // https://www.lsts.pt/docs/imc/imc-5.4.11/Maneuvering.html#low-level-control-maneuver
+  name: 'lowLevelControlManeuver', // This must be treated seperablely because it encapsulates other messages
+  id: {
+    value: 455,
+    datatype: datatypes.uint_16t,
+  },
+  message: [
+    {
+      name: 'control',
+      datatype: datatypes.recursive,
+    },
+    {
+      name: 'duration',
+      datatype: datatypes.uint_16t,
+    },
+  ],
+};
+
+const goToMetadata = {
+  // https://www.lsts.pt/docs/imc/imc-5.4.11/Maneuvering.html
+  name: messages.goTo,
+  length: 54,
+  id: {
+    value: 450,
+    datatype: datatypes.uint_16t,
+  },
+  message: [
+    {
+      name: 'timeout',
+      datatype: datatypes.uint_16t,
+    },
+    {
+      name: 'lat',
+      datatype: datatypes.fp64_t,
+    },
+    {
+      name: 'lon',
+      datatype: datatypes.fp64_t,
+    },
+    {
+      name: 'z',
+      datatype: datatypes.fp32_t,
+    },
+    {
+      name: 'z_units',
+      datatype: datatypes.uint_8t,
+    },
+    {
+      name: 'speed',
+      datatype: datatypes.fp32_t,
+    },
+    {
+      name: 'speed_units',
+      datatype: datatypes.uint_8t,
+    },
+    {
+      name: 'roll',
+      datatype: datatypes.fp64_t,
+    },
+    {
+      name: 'pitch',
+      datatype: datatypes.fp64_t,
+    },
+    {
+      name: 'yaw',
+      datatype: datatypes.fp64_t,
+    },
+  ],
+};
+
+const netFollowMetadata = {
+  // https://www.lsts.pt/docs/imc/imc-5.4.11/Maneuvering.html#custom-maneuver
+  name: messages.netFollow,
+  length: 33,
+  id: {
+    value: 465,
+    datatype: datatypes.uint_16t,
+  },
+  message: [
+    {
+      name: 'timeout',
+      datatype: datatypes.uint_16t,
+    },
+    {
+      name: 'name',
+      datatype: datatypes.uint_32t,
+      value: 151110,
+    },
+    {
+      name: 'd',
+      datatype: datatypes.fp64_t,
+    },
+    {
+      name: 'v',
+      datatype: datatypes.fp64_t,
+    },
+    {
+      name: 'z',
+      datatype: datatypes.fp64_t,
+    },
+    {
+      name: 'z_units',
+      datatype: datatypes.uint_8t,
+    },
+  ],
+};
+
+const customNetFollowStateMetadata = {
+  // https://www.lsts.pt/docs/imc/imc-5.4.11/Custom.html
+  name: messages.customNetFollowState,
+  length: 18,
+  id: {
+    value: 1002,
+    datatype: datatypes.uint_16t,
+  },
+  message: [
+    {
+      name: 'd',
+      datatype: datatypes.fp32_t,
+    },
+    {
+      name: 'v',
+      datatype: datatypes.fp32_t,
+    },
+    {
+      name: 'angle',
+      datatype: datatypes.fp64_t,
+    },
+  ],
+};
+
+module.exports = {
+  datatypes,
+  estimatedStateMetadata,
+  customNetFollowStateMetadata,
+  entityStateMetadata,
+  desiredControlMetadata,
+  lowLevelControlManeuverMetadata,
+  desiredHeadingMetadata,
+  desiredZMetadata,
+  netFollowMetadata,
+  goToMetadata,
+};

--- a/public/TCP/IMCtest.js
+++ b/public/TCP/IMCtest.js
@@ -142,3 +142,17 @@ console.log(bufcustomNetFollow);
 
 let resultcustomNetFollow = decode(bufcustomNetFollow);
 console.log(resultcustomNetFollow);
+
+// composedExample ====================================
+console.log('composedExample =============================');
+
+let totalLength =
+  bufDesiredControl.length + bufDesiredZ.length + bufdesiredHeading.length;
+let resultComposed = decode(
+  Buffer.concat(
+    [bufDesiredControl, bufDesiredZ, bufdesiredHeading],
+    totalLength,
+  ),
+);
+
+console.log(resultComposed);

--- a/public/TCP/TCPServerMockUp.js
+++ b/public/TCP/TCPServerMockUp.js
@@ -7,9 +7,9 @@ const host = '127.0.0.1';
 /* eslint-disable no-unused-vars */
 
 const states = {
-  manual: 'manual',
-  NF: 'NF',
-  DP: 'DP',
+  manual: 0,
+  NF: 1,
+  DP: 2,
 };
 
 /* eslint no-unused-vars: ["error", { "args": "none" }] */

--- a/public/TCP/TCPServerMockUp.js
+++ b/public/TCP/TCPServerMockUp.js
@@ -3,6 +3,67 @@ const net = require('net');
 const port = 5000;
 const host = '127.0.0.1';
 
+// States for IMC ==============================================
+/* eslint-disable no-unused-vars */
+
+const states = {
+  manual: 'manual',
+  NF: 'NF',
+  DP: 'DP',
+};
+
+/* eslint no-unused-vars: ["error", { "args": "none" }] */
+const entityState = {
+  state: states.manual,
+  flags: {
+    DP: true,
+    NF: true,
+  },
+  description: 131072,
+};
+
+const manualState = {
+  x: 0,
+  y: 0,
+  z: 0,
+  k: 0,
+  m: 0,
+  n: 0,
+  flags: {
+    x: true,
+    y: true,
+    z: true,
+    k: true,
+    m: true,
+    n: true,
+  },
+};
+
+const estimatedState = {
+  lat: 1.0,
+  lon: 2.0,
+  height: 3.0,
+  x: 4.0,
+  y: 0,
+  z: 0,
+  phi: 0,
+  theta: 0,
+  psi: 0,
+  u: 0,
+  v: 0,
+  w: 0,
+  vx: 0,
+  vy: 0,
+  vz: 0,
+  p: 0,
+  q: 0,
+  r: 0,
+  depth: 0,
+  alt: 0,
+};
+/* eslint-disable no-unused-vars */
+// End states IMC ==============================================
+
 console.log(`Waiting for client to connect to host ${host} port ${port}`);
 
 const server = new net.createServer(socket => {
@@ -11,12 +72,16 @@ const server = new net.createServer(socket => {
   socket.on('data', buf => {
     console.log(`[${Date.now()}] Recieved data from client:`);
     console.log(decodeRecievedData(buf));
+  });
 
+  const sendData = () => {
     // Respond when getting data
     let doubleArray = new Float64Array([1.5, 2.5, 3.5, 4.5, 5.5, 6.5]);
     console.log(`Sending byte array ${doubleArray}\n`);
     socket.write(Buffer.from(doubleArray.buffer));
-  });
+  };
+
+  setInterval(sendData, 200);
 });
 
 server.listen(port, host);


### PR DESCRIPTION
This PR implements encoding and decoding for all our IMC messages. It will now be possible to do this:

```javascript
const { encode, decode } = require('./IMC');

const netFollow = {
  timeout: 132,
  d: 1.1,
  v: 2.2,
  z: 3.3,
  z_units: 3,
};

let bufnetFollow = encode.netFollow(netFollow);
// send buffer with TCP

// And decode like this:
let resultnetFollow = decode(bufnetFollow);
```

This turned out to be a rather big PR. I have done some manual testing in the imc.test.js file. This should be turned into a proper unit test when we get a unit test framework.

Feature that is not included in this PR: Ability to decode a buffer that consist of more that one message concatenated