### PR TITLE
style/move mode to right

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -61,7 +61,7 @@ global.bias = {
 global.mode = {
   currentMode: 0,
   nfAvailable: true,
-  dpAvailable: false,
+  dpAvailable: true,
 };
 
 /**

--- a/src/VideoComponents/ModeWidget.jsx
+++ b/src/VideoComponents/ModeWidget.jsx
@@ -125,8 +125,10 @@ class ModeWidget extends Component {
         style={{ fontSize: this.state.fontSizeMode + 'px' }}
         onLoad={this.updateDimensions}
       >
-        {this.widget}
-        <p>{this.modeLabel}</p>
+        <div>
+          <p>{this.modeLabel}</p>
+          {this.widget}
+        </div>
       </div>
     );
   }

--- a/src/VideoComponents/VideoApp.jsx
+++ b/src/VideoComponents/VideoApp.jsx
@@ -37,11 +37,6 @@ function VideoApp() {
         deviceId={deviceId}
         setDeviceId={setDeviceId}
       />
-      <BiasWidget
-        u={biasValues['surge']}
-        v={biasValues['sway']}
-        w={biasValues['heave']}
-      />
       <HeadingWidget
         heading={sensorValues['yaw']}
         isLocked={settingsValues['autoheading']}
@@ -52,17 +47,28 @@ function VideoApp() {
         isLocked={settingsValues['autodepth']}
         lockedValue={settingsValues['heave']}
       />
-      <ModeWidget
-        currentMode={remote.getGlobal('mode')['currentMode']}
-        nfAvailable={remote.getGlobal('mode')['nfAvailable']}
-      />
-      <MiniMapWidget
-        north={sensorValues['north']}
-        east={sensorValues['east']}
-        yaw={sensorValues['yaw']}
-        boatHeading={0}
-        maxDistance={5}
-      />
+      <div className="rightWidgetsPlacer">
+        <div className="rightWidgets">
+          <div className="miniMapPlacer">
+            <MiniMapWidget
+              north={sensorValues['north']}
+              east={sensorValues['east']}
+              yaw={sensorValues['yaw']}
+              boatHeading={0}
+              maxDistance={5}
+            />
+          </div>
+          <ModeWidget
+            currentMode={remote.getGlobal('mode')['currentMode']}
+            nfAvailable={remote.getGlobal('mode')['nfAvailable']}
+          />
+          <BiasWidget
+            u={biasValues['surge']}
+            v={biasValues['sway']}
+            w={biasValues['heave']}
+          />
+        </div>
+      </div>
       <GamepadWrapper className="GamepadWrapper" />
       <KeyboardWrapper className="KeyboardInput" />
       <VideoFeed deviceId={deviceId} hidden={transparent} />

--- a/src/VideoComponents/css/BiasWidget.css
+++ b/src/VideoComponents/css/BiasWidget.css
@@ -1,4 +1,5 @@
 .BiasWidget {
-  right: 50px;
-  bottom: 50px;
+  position: relative;
+  height: 30%;
+  width: 100%;
 }

--- a/src/VideoComponents/css/MiniMapWidget.css
+++ b/src/VideoComponents/css/MiniMapWidget.css
@@ -2,9 +2,6 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  position: absolute;
-  top: 100px;
-  right: 50px;
 }
 
 .zoom {

--- a/src/VideoComponents/css/ModeWidget.css
+++ b/src/VideoComponents/css/ModeWidget.css
@@ -1,18 +1,13 @@
 .ModeWidget {
-  position: fixed;
   color: white;
-
-  width: 250px;
-
-  left: -9999px;
-  right: -9999px;
-  margin: auto;
-  bottom: 20px;
-
+  width: 100%;
+  height: 30%;
   font-family: Arial, Helvetica, sans-serif;
   text-align: center;
-
   font-size: 20px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
 
 .ModeWidget canvas {
@@ -22,6 +17,7 @@
 
 .ModeWidget p {
   display: block;
+  margin-top: 0;
 }
 
 .ModeWidget img {
@@ -53,14 +49,13 @@
 
 #DynPos {
   font-size: 14px;
-  left: -9999px;
-  right: -9999px;
-  margin: auto;
+  display: flex;
+  justify-content: center;
 }
 
 #DynPos table {
   border-collapse: separate;
-  border-spacing: 30px 5px;
+  border-spacing: 5px;
 }
 
 #DynPos thead {

--- a/src/VideoComponents/css/VideoApp.css
+++ b/src/VideoComponents/css/VideoApp.css
@@ -7,3 +7,30 @@
   height: 100%;
   border: solid 0.3px white;
 }
+
+.rightWidgets {
+  height: 90%;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-evenly;
+  align-items: center;
+}
+
+.rightWidgetsPlacer {
+  position: absolute;
+  right: 15px;
+  height: 100%;
+  width: 180px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.miniMapPlacer {
+  display: flex;
+  width: 100%;
+  height: 30%;
+  justify-content: center;
+}


### PR DESCRIPTION
Suggestion to move mode to the right.

This allows us to create a dark background with some transparancy for the widgets to be more visible as well if we want that.

After:
![image](https://user-images.githubusercontent.com/31652936/67478510-82990000-f65c-11e9-924b-694f9c28efcc.png)

Before:
![image](https://user-images.githubusercontent.com/31652936/67478613-aceabd80-f65c-11e9-8118-6e1772676c00.png)
