### PR TITLE
Fix/serial-port

### DIFF
--- a/public/serial/nmea.js
+++ b/public/serial/nmea.js
@@ -13,6 +13,10 @@ class SerialPortObject {
       baudRate: baudRate,
     });
 
+    this.port.on('error', () => {
+      console.log('Could not connect to serial port ' + port);
+    });
+
     // Set up a serial parser
     this.parser = new Readline();
     this.port.pipe(this.parser);


### PR DESCRIPTION
This tiny fix ensures that a sensible error message is shown in case of a failed connection attempt to a serial port.