### PR TITLE
Fix/no videofeed bug

### DIFF
--- a/src/VideoComponents/VideoPicker.jsx
+++ b/src/VideoComponents/VideoPicker.jsx
@@ -69,23 +69,38 @@ class VideoPicker extends Component {
     });
   };
 
-  // Creates buttons inside the dropdown menu based on the devices-state
-  populateDropdown = () => {
-    const dropdown = document.getElementById('video-dropdown-content');
-    dropdown.innerHTML = '';
-    Object.keys(this.state.devices).forEach(key => {
-      const btn = document.createElement('button');
+  createButton = (label, clickable) => {
+    const btn = document.createElement('button');
+    if (clickable) {
       btn.onclick = event => {
         this.switchFeed(event);
         this.props.handleClick(this.state.currentID);
       };
-      btn.innerHTML = key;
-      btn.classList.add('videoButton');
-      if (key === this.state.currentLabel) {
-        btn.classList.add('selectedFeed');
-      }
-      dropdown.appendChild(btn);
-    });
+    } else {
+      btn.classList.add('noVideoFoundBtn');
+    }
+    btn.innerHTML = label;
+    btn.classList.add('videoButton');
+    if (label === this.state.currentLabel) {
+      btn.classList.add('selectedFeed');
+    }
+    return btn;
+  };
+
+  // Creates buttons inside the dropdown menu based on the devices-state
+  populateDropdown = () => {
+    const dropdown = document.getElementById('video-dropdown-content');
+    dropdown.innerHTML = '';
+    const deviceKeys = Object.keys(this.state.devices);
+    if (deviceKeys.length > 0) {
+      deviceKeys.forEach(key => {
+        const btn = this.createButton(key, true);
+        dropdown.appendChild(btn);
+      });
+    } else {
+      const btn = this.createButton('No video device found');
+      dropdown.appendChild(btn, false);
+    }
   };
 
   // componentDidMount is built-in function that is called after the inital rendering of the component

--- a/src/VideoComponents/VideoPicker.jsx
+++ b/src/VideoComponents/VideoPicker.jsx
@@ -41,6 +41,9 @@ class VideoPicker extends Component {
   setDefaultID = () => {
     let { devices } = this.state;
     const keys = Object.keys(devices);
+    if (keys.length === 0) {
+      return;
+    }
     let ID = devices[keys[0]].currentID;
     let label = keys[0];
     keys.forEach(key => {

--- a/src/VideoComponents/css/VideoPicker.css
+++ b/src/VideoComponents/css/VideoPicker.css
@@ -86,3 +86,8 @@
   font-weight: bold;
   font-size: 20px;
 }
+
+.noVideoFoundBtn:hover {
+  cursor: default !important;
+  background-color: rgb(68, 68, 68) !important;
+}


### PR DESCRIPTION
This fixes a bug pointed out by @greenbech. The bug crashed the application if no video feed was found - now it does not crash, and a label with "no video feed was found" appears. The new label is unclickable and does not behave like a button.

![image](https://user-images.githubusercontent.com/31652936/68388973-1d680300-0162-11ea-890a-743dc38cf855.png)
