### PR TITLE
Fix: Make Custom GoTo use Global State

### DIFF
--- a/public/TCP/TCPClient.js
+++ b/public/TCP/TCPClient.js
@@ -198,10 +198,10 @@ function sendIMCData(client) {
     // TODO: Get proper value from global state
     buf = encode.customGoTo({
       timeout: 10,
-      x: 1.1,
-      y: 2.2,
-      z: global.toROV.heave,
-      yaw: global.toROV.yaw,
+      x: global.dynamicpositioning.north,
+      y: global.dynamicpositioning.east,
+      z: global.dynamicpositioning.down,
+      yaw: global.dynamicpositioning.yaw,
     });
   }
 


### PR DESCRIPTION
This closes #218 .

Custom GoTo message now uses `global.dynamicpositioning`