### PR TITLE
refactor/change controls

### DIFF
--- a/public/TCP/TCPClient.js
+++ b/public/TCP/TCPClient.js
@@ -1,6 +1,7 @@
 const net = require('net');
 const { encodeData, decodeData } = require('./coding');
 const { encode, decode, messages } = require('./IMC/IMC');
+const { sendVibrationRequest } = require('./../controls/mapping');
 
 const messageLength = 256;
 
@@ -251,6 +252,7 @@ function setSafetyControls() {
   global.toROV.autoheading = true; // Start autoheading
   global.toROV.heave = global.fromROV.down; // Sets heave to current down - heave is used by autodepth
   global.toROV.yaw = global.fromROV.yaw; // Sets yaw to current yaw - yaw is used by autoheading
+  sendVibrationRequest(false); // Sends hard vibration to gamepad
 }
 
 module.exports = { getConnectedClient, sendData, sendIMCData, decodeImcData };

--- a/public/__tests__/mapping.test.js
+++ b/public/__tests__/mapping.test.js
@@ -262,23 +262,24 @@ test(prefix + 'AutoHeading/AutoDepth clicks', () => {
 // NF
 test(prefix + 'NF clicks', () => {
   global.mode.currentMode = 2;
-  handleClick([{ button: 'LeftTrigger' }]);
+  handleClick([{ button: 'DPadLeft' }]);
   expect(global.netfollowing.distance).toBe(0.9);
-  handleClick([{ button: 'RightTrigger' }, { button: 'RightTrigger' }]);
+  handleClick([{ button: 'DPadRight' }, { button: 'DPadRight' }]);
   expect(global.netfollowing.distance).toBe(1.1);
   handleClick([{ button: 'Y' }]);
   expect(global.netfollowing.distance).toBe(0);
   expect(global.netfollowing.velocity).toBe(0);
   handleClick([
     { button: 'DPadUp' },
+    { button: 'DPadUp' },
     { button: 'DPadDown' },
-    { button: 'RB' },
     { button: 'LB' },
+    { button: 'RB' },
   ]);
-  expect(global.netfollowing.velocity).toBe(0);
+  expect(global.netfollowing.velocity).toBe(0.1);
   expect(global.netfollowing.depth).toBe(0.1);
   handleClick([{ button: 'Start' }]);
-  expect(global.mode.currentMode).toBe(0);
+  expect(global.mode.currentMode).toBe(1);
   handleClick([{ button: 'Back' }]);
   expect(global.mode.currentMode).toBe(2);
   handleClick([{ button: 'Back' }]);
@@ -290,7 +291,7 @@ test(prefix + 'DP clicks', () => {
   handleClick([{ button: 'Start' }]);
   expect(global.mode.currentMode).toBe(1);
   handleClick([{ button: 'Back' }]);
-  expect(global.mode.currentMode).toBe(0);
+  expect(global.mode.currentMode).toBe(2);
   handleClick([{ button: 'Start' }]);
   expect(global.mode.currentMode).toBe(1);
   handleClick([{ button: 'Start' }]);

--- a/public/controls/mapping.js
+++ b/public/controls/mapping.js
@@ -206,22 +206,10 @@ function handleManual({ button, value }) {
 
     // BACK AND START BUTTONS | SWITCH MODE and reset bias
     case 'Back': // turn NF on if available
-      if (global.mode.nfAvailable) {
-        sendVibrationRequest(true);
-        switchToMode('nf');
-        setNFToCurrentDepth();
-      } else {
-        sendVibrationRequest(false);
-      }
+      switchToMode('nf');
       break;
     case 'Start': // turn DP on if available
-      if (global.mode.dpAvailable) {
-        sendVibrationRequest(true);
-        switchToMode('dp');
-        setDPToCurrentPosition();
-      } else {
-        sendVibrationRequest(false);
-      }
+      switchToMode('dp');
       break;
   }
 }
@@ -261,12 +249,10 @@ function handleNF({ button }) {
     // BACK AND START BUTTONS | TURN ON MANUAL MODE
     // Sets to manual if any of the mode buttons are clicked
     case 'Back':
-      sendVibrationRequest(true);
       switchToMode('manual');
       break;
     case 'Start':
-      sendVibrationRequest(true);
-      switchToMode('manual');
+      switchToMode('dp');
       break;
   }
 }
@@ -277,11 +263,9 @@ function handleDP({ button }) {
     // BACK AND START BUTTONS | TURN ON MANUAL MODE
     // Sets to manual if any of the mode buttons are clicked
     case 'Back':
-      sendVibrationRequest(true);
-      switchToMode('manual');
+      switchToMode('nf');
       break;
     case 'Start':
-      sendVibrationRequest(true);
       switchToMode('manual');
       break;
   }
@@ -350,12 +334,20 @@ function setNfParameters(type, positive) {
 //Sets global mode to modeNumber and resets all bias
 // Manual/DP/NF
 function switchToMode(modeName) {
-  if (Object.keys(global.mode).indexOf(modeName) < 0) {
-    console.log(`Could not switch to invalid mode ${modeName}`);
-    return;
+  const availabilityKey = modeName + 'Available';
+  const available = modeName === 'manual' || global.mode[availabilityKey];
+  if (available) {
+    resetAllBias();
+    global.mode.currentMode = global.mode[modeName];
+    sendVibrationRequest(true);
+    if (modeName === 'dp') {
+      setDPToCurrentPosition();
+    } else if (modeName === 'nf') {
+      setNFToCurrentDepth();
+    }
+  } else {
+    sendVibrationRequest(false);
   }
-  global.mode.currentMode = global.mode[modeName];
-  resetAllBias();
 }
 
 // Sets global DP to current position (fromROV)

--- a/public/controls/mapping.js
+++ b/public/controls/mapping.js
@@ -379,4 +379,9 @@ function sendVibrationRequest(positive) {
   }
 }
 
-module.exports = { handleClick, handleButton, resetAllBias };
+module.exports = {
+  handleClick,
+  handleButton,
+  resetAllBias,
+  sendVibrationRequest,
+};

--- a/public/controls/mapping.js
+++ b/public/controls/mapping.js
@@ -229,10 +229,10 @@ function handleManual({ button, value }) {
 // Handles NF mode controls
 function handleNF({ button }) {
   switch (button) {
-    case 'LeftTrigger': // - distance
+    case 'DPadLeft': // - distance
       setNfParameters('distance', false);
       break;
-    case 'RightTrigger': // + distance
+    case 'DPadRight': // + distance
       setNfParameters('distance', true);
       break;
 
@@ -245,17 +245,17 @@ function handleNF({ button }) {
       break;
 
     // SET NF PARAMETERS
-    case 'DPadUp': //Depth (-)
-      setNfParameters('depth', false);
-      break;
-    case 'DPadDown': //Depth (+)
-      setNfParameters('depth', true);
-      break;
-    case 'RB': //Velocity (+)
+    case 'DPadUp': //Velocity (+)
       setNfParameters('velocity', true);
       break;
-    case 'LB': //Velocity (-)
+    case 'DPadDown': //Velocity (-)
       setNfParameters('velocity', false);
+      break;
+    case 'RB': //Depth (+)
+      setNfParameters('depth', true);
+      break;
+    case 'LB': //Depth (-)
+      setNfParameters('depth', false);
       break;
 
     // BACK AND START BUTTONS | TURN ON MANUAL MODE

--- a/src/ControlComponents/css/SettingsApp.css
+++ b/src/ControlComponents/css/SettingsApp.css
@@ -28,22 +28,13 @@
   width: 90%;
 }
 
-.SettingsApp input {
-  width: 100%;
-  padding: 0;
-  font-size: 14px;
-  box-sizing: border-box;
-  border: 0.5px solid black;
-  padding-left: 5px;
-  height: 35px;
-  -webkit-app-region: no-drag;
-}
-
+.SettingsApp input,
 .MessageProtocolDropdown {
   width: 100%;
   padding: 0;
   font-size: 14px;
   box-sizing: border-box;
+  border: 0.5px solid black;
   padding-left: 5px;
   height: 35px;
   -webkit-app-region: no-drag;


### PR DESCRIPTION
**Features:** 
close #243: Change nf controls to proposed. Note that the bumpers (the uppermost of the buttons at the back) will be used for depth. This is because the triggers (the bottommost buttons at the back) dont send discrete values, which makes it hard to increment the depth.
close #252: Vibrate when automatically turn of dp or nf
close #246: Go from dp to nf directly

I have tested pretty thoroughly that this works with xbox-controller and that it does not break any functionality.