### PR TITLE
refactor/show devtools for mockup only in devmode

### DIFF
--- a/public/utils/windows.js
+++ b/public/utils/windows.js
@@ -160,7 +160,10 @@ function createMockupWindow() {
       ? 'http://localhost:3000?mockupWindow'
       : `file://${path.join(__dirname, '../../build/index.html?mockupWindow')}`,
   );
-  mockupWindow.webContents.openDevTools();
+  if (isDev) {
+    mockupWindow.webContents.openDevTools();
+  }
+
   // Handle garbage collection
   mockupWindow.on('close', function() {
     mockupWindow = null;


### PR DESCRIPTION
close #254 

Devtools pops up in the production version for mockup. This fixes that