### PR TITLE
fix: read degrees in dp mode

### DIFF
--- a/public/__tests__/mapping.test.js
+++ b/public/__tests__/mapping.test.js
@@ -235,10 +235,7 @@ test(prefix + 'set multiple biases and reset', () => {
       },
     ]);
   });
-  handleClick([
-    { button: 'LB', value: 1.0 },
-    { button: 'X', value: 1.0 },
-  ]);
+  handleClick([{ button: 'LB', value: 1.0 }, { button: 'X', value: 1.0 }]);
   bias['surge'] = biasIncrease;
   bias['sway'] = biasIncrease;
   expect(global.bias).toStrictEqual(bias);

--- a/src/ControlComponents/DynamicPositioningMode.jsx
+++ b/src/ControlComponents/DynamicPositioningMode.jsx
@@ -4,7 +4,12 @@ import Switch from './Switch';
 import Title from './Title';
 import './css/Mode.css';
 import ModeEnum from '../constants/modeEnum';
-import { normalize, degreesToRadians, roundNumber } from './../utils/utils';
+import {
+  normalize,
+  degreesToRadians,
+  roundNumber,
+  radiansToDegrees,
+} from './../utils/utils';
 import { resetAllBias } from './../utils/IPCutils';
 import ModeInput from './ModeInput';
 
@@ -108,7 +113,11 @@ export default function DynamicPositioningMode({
   // Updates input-fields and the global DP settings to the current position
   const setCurrentPosition = () => {
     attributes.forEach(attribute => {
-      const currentPosition = Number(fromROV[attribute]);
+      let currentPosition;
+      console.log(fromROV[attribute]);
+      attribute === 'yaw'
+        ? (currentPosition = radiansToDegrees(Number(fromROV[attribute])))
+        : (currentPosition = Number(fromROV[attribute]));
       const inputField = document.getElementById(attribute);
       inputField.value = roundNumber(currentPosition);
       remote.getGlobal('dynamicpositioning')[attribute] = currentPosition;

--- a/src/ControlComponents/DynamicPositioningMode.jsx
+++ b/src/ControlComponents/DynamicPositioningMode.jsx
@@ -114,7 +114,6 @@ export default function DynamicPositioningMode({
   const setCurrentPosition = () => {
     attributes.forEach(attribute => {
       let currentPosition;
-      console.log(fromROV[attribute]);
       attribute === 'yaw'
         ? (currentPosition = radiansToDegrees(Number(fromROV[attribute])))
         : (currentPosition = Number(fromROV[attribute]));

--- a/src/ControlComponents/DynamicPositioningMode.jsx
+++ b/src/ControlComponents/DynamicPositioningMode.jsx
@@ -113,10 +113,10 @@ export default function DynamicPositioningMode({
   // Updates input-fields and the global DP settings to the current position
   const setCurrentPosition = () => {
     attributes.forEach(attribute => {
-      let currentPosition;
-      attribute === 'yaw'
-        ? (currentPosition = radiansToDegrees(Number(fromROV[attribute])))
-        : (currentPosition = Number(fromROV[attribute]));
+      const currentPosition =
+        attribute === 'yaw'
+          ? radiansToDegrees(Number(fromROV[attribute]))
+          : Number(fromROV[attribute]);
       const inputField = document.getElementById(attribute);
       inputField.value = roundNumber(currentPosition);
       remote.getGlobal('dynamicpositioning')[attribute] = currentPosition;

--- a/src/MockupComponents/FromROV.jsx
+++ b/src/MockupComponents/FromROV.jsx
@@ -29,7 +29,7 @@ export default function FromROV() {
 
   function changeCustomEstimatedState(value, name) {
     let tempState = customEstimatedStateMessage;
-    tempState[name] = isNaN(parseInt(value)) ? 0 : parseInt(value);
+    tempState[name] = isNaN(Number(value)) ? 0 : Number(value);
     console.log(tempState);
     setCustomEstimatedStateMessage(tempState);
     ipcRenderer.send(

--- a/src/MockupComponents/NFView.jsx
+++ b/src/MockupComponents/NFView.jsx
@@ -12,7 +12,7 @@ export default function NFView() {
 
   function changeCustomNfState(value, name) {
     let tempState = customNfStateMessage;
-    tempState[name] = isNaN(parseInt(value)) ? 0 : parseInt(value);
+    tempState[name] = isNaN(Number(value)) ? 0 : Number(value);
     console.log(tempState);
     setcustomNfStateMessage(tempState);
     ipcRenderer.send('rov-mock-up-send-custom-nf-state', tempState);


### PR DESCRIPTION
Heading field in dp mode now converts yaw to degrees before displaying it in the input field.
Also noticed the mockup only handles integers on input. Changed this so we can input numbers.